### PR TITLE
fix: resolve CI build failure and ff-run notarization

### DIFF
--- a/Sources/Terminal/TerminalView.swift
+++ b/Sources/Terminal/TerminalView.swift
@@ -491,7 +491,7 @@ final class TerminalView: NSView {
     }
 }
 
-extension TerminalView: @MainActor NSTextInputClient {}
+extension TerminalView: @preconcurrency NSTextInputClient {}
 
 // MARK: - NSScreen display ID helper
 

--- a/project.yml
+++ b/project.yml
@@ -96,7 +96,7 @@ targets:
           mkdir -p "${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers"
           cp -f "${BUILT_PRODUCTS_DIR}/ff-run" "${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/ff-run"
           chmod +x "${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/ff-run"
-          codesign --force --sign "${EXPANDED_CODE_SIGN_IDENTITY}" --timestamp=none --generate-entitlement-der "${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/ff-run"
+          codesign --force --sign "${EXPANDED_CODE_SIGN_IDENTITY}" --timestamp --generate-entitlement-der "${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Helpers/ff-run"
         name: Bundle ff-run
         outputFiles:
           - $(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Helpers/ff-run


### PR DESCRIPTION
## Summary
- Use `@preconcurrency` for `NSTextInputClient` conformance to fix strict concurrency errors on Xcode 16.3+ (CI runner)
- Use secure timestamp (`--timestamp`) when codesigning ff-run helper binary so Apple notarization accepts it

## Test plan
- [ ] Merge to main and verify the release workflow passes the build step
- [ ] Verify notarization succeeds with the timestamped ff-run binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)