### PR TITLE
fix(ci): build ghostty xcframework before release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,13 @@ jobs:
         with:
           submodules: true
 
-      - name: Install XcodeGen
-        run: brew install xcodegen
+      - name: Install dependencies
+        run: brew install xcodegen zig
+
+      - name: Build Ghostty xcframework
+        run: |
+          cd ghostty
+          zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
 
       - name: Generate Xcode project
         run: xcodegen generate


### PR DESCRIPTION
## Summary
- Add `zig` to brew install and build ghostty xcframework before xcodebuild
- Without this, the linker fails with `library 'ghostty' not found` because the xcframework isn't compiled
- Mirrors the existing build step from `test-ghostty.yml`

## Test plan
- [ ] Merge to main and verify the release workflow passes the build + link step

🤖 Generated with [Claude Code](https://claude.com/claude-code)