### PR TITLE
fix(ci): skip ghostty app bundle, only build xcframework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build Ghostty xcframework
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 
       - name: Generate Xcode project
         run: xcodegen generate


### PR DESCRIPTION
## Summary
- Add `-Demit-macos-app=false` to the zig build step so it only builds the xcframework library, not the full Ghostty macOS app
- The app build was failing on x86_64 compilation (DockTilePlugin target) which we don't need

## Test plan
- [ ] Merge and verify release workflow passes the ghostty build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)