### PR TITLE
fix(ci): fetch Apple notarization log on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,21 @@ jobs:
 
       - name: Notarize
         run: |
-          xcrun notarytool submit "build/release/$DMG_NAME" \
+          SUBMIT_OUT=$(xcrun notarytool submit "build/release/$DMG_NAME" \
             --keychain-profile "notarize-profile" \
             --keychain "$RUNNER_TEMP/signing.keychain-db" \
-            --wait
+            --wait 2>&1) || true
+          echo "$SUBMIT_OUT"
+
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | grep 'id:' | head -1 | awk '{print $2}')
+
+          if echo "$SUBMIT_OUT" | grep -q "status: Invalid"; then
+            echo "::error::Notarization failed. Fetching detailed log..."
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --keychain-profile "notarize-profile" \
+              --keychain "$RUNNER_TEMP/signing.keychain-db"
+            exit 1
+          fi
 
           xcrun stapler staple "build/release/$DMG_NAME"
 


### PR DESCRIPTION
## Summary
- When notarization returns `Invalid`, fetch and print Apple's detailed rejection log before failing
- This will tell us exactly which binary/entitlement caused the rejection (likely the ff-run `--timestamp=none` issue we already fixed in project.yml)

## Test plan
- [ ] Merge and trigger a release; if notarization fails again, the log will show the reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)