### PR TITLE
fix: let release-please bump version in Info.plist

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,6 +6,12 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "Resources/Info.plist"
+        }
+      ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,9 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <!-- x-release-please-start-version -->
+    <string>0.1.7</string>
+    <!-- x-release-please-end -->
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary
- Add `x-release-please-version` annotations to Info.plist so the bundle version is updated on each release
- Configure `extra-files` with generic updater in release-please config
- Set current version to 0.1.7 to match latest release

Previously every release shipped with 0.1.0 in the About dialog.

## Test plan
- [ ] Next release PR should include Info.plist version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)