### PR TITLE
fix(ci): remove --deep from app re-signing, add debug logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,9 @@ jobs:
             codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options=runtime "$bin"
           done
 
-          # Re-sign the main app bundle (deep sign to catch anything missed)
+          # Sign the main app binary (not --deep, nested code is already signed above)
           codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options=runtime \
-            --entitlements Resources/ff2.entitlements --deep "$APP"
+            --entitlements Resources/ff2.entitlements "$APP"
 
           codesign --verify --verbose=2 --deep --strict "$APP"
 

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -229,21 +229,31 @@ enum GitOperations {
     }
 
     private static func run(args: [String], in directory: String) -> String? {
-        guard let gitPath else { return nil }
+        guard let gitPath else {
+            NSLog("[FF] git run: gitPath is nil")
+            return nil
+        }
         let process = Process()
         let pipe = Pipe()
+        let errPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: gitPath)
         process.arguments = args
         process.currentDirectoryURL = URL(fileURLWithPath: directory)
         process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
+        process.standardError = errPipe
         do {
             try process.run()
             process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let errStr = String(data: errData, encoding: .utf8) ?? ""
+            guard process.terminationStatus == 0 else {
+                NSLog("[FF] git \(args.joined(separator: " ")) failed (exit \(process.terminationStatus)): \(errStr)")
+                return nil
+            }
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             return String(data: data, encoding: .utf8)
         } catch {
+            NSLog("[FF] git \(args.joined(separator: " ")) threw: \(error)")
             return nil
         }
     }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -312,16 +312,24 @@ struct ProjectSidebar: View {
     @AppStorage("factoryfloor.symlinkEnv") private var symlinkEnv: Bool = true
 
     private func addWorkstream(for projectID: UUID, bypassPermissions: Bool? = nil) {
-        guard let index = projects.firstIndex(where: { $0.id == projectID }) else { return }
+        NSLog("[FF] addWorkstream called for projectID=\(projectID)")
+        guard let index = projects.firstIndex(where: { $0.id == projectID }) else {
+            NSLog("[FF] addWorkstream: project not found")
+            return
+        }
         let project = projects[index]
+        NSLog("[FF] addWorkstream: project=\(project.name) dir=\(project.directory)")
 
         guard GitOperations.isGitRepo(at: project.directory) else {
+            NSLog("[FF] addWorkstream: not a git repo")
             showNotGitRepoError = true
             return
         }
+        NSLog("[FF] addWorkstream: is git repo")
 
         let existingNames = Set(project.workstreams.map(\.name))
         let name = NameGenerator.generate(avoiding: existingNames)
+        NSLog("[FF] addWorkstream: generated name=\(name)")
 
         guard let worktreePath = GitOperations.createWorktree(
             projectPath: project.directory,
@@ -330,9 +338,11 @@ struct ProjectSidebar: View {
             branchPrefix: branchPrefix,
             symlinkEnv: symlinkEnv
         ) else {
+            NSLog("[FF] addWorkstream: createWorktree FAILED")
             showWorktreeError = true
             return
         }
+        NSLog("[FF] addWorkstream: worktree created at \(worktreePath)")
 
         let bypass = bypassPermissions ?? defaultBypass
         let workstream = Workstream(name: name, worktreePath: worktreePath, bypassPermissions: bypass)
@@ -341,6 +351,7 @@ struct ProjectSidebar: View {
         expandedProjects.insert(projectID)
         selection = .workstream(workstream.id)
         onProjectsChanged()
+        NSLog("[FF] addWorkstream: done")
     }
 
     @EnvironmentObject private var surfaceCache: TerminalSurfaceCache


### PR DESCRIPTION
## Summary
- Remove `--deep` from the main app codesign step. `--deep` re-signs all nested code (frameworks, helpers) with the app's entitlements, potentially breaking their signatures. The individual re-signing steps already handle nested code correctly.
- Add NSLog debug logging to `addWorkstream` and git `run()` to diagnose the production workspace creation failure that doesn't reproduce locally.

## Test plan
- [ ] Merge, release, install from Homebrew, verify workspace creation works
- [ ] If it still fails, the [FF] logs in Console.app will show exactly where

🤖 Generated with [Claude Code](https://claude.com/claude-code)