### PR TITLE
fix: pass env vars to tmux sessions via -e flags

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -50,11 +50,12 @@ enum TmuxSession {
     /// Dedicated socket name so we don't interfere with the user's tmux.
     private static let socketName = AppConstants.appID
 
-    static func wrapCommand(tmuxPath: String, sessionName: String, command: String?) -> String {
+    static func wrapCommand(tmuxPath: String, sessionName: String, command: String?, environmentVars: [String: String] = [:]) -> String {
         let escaped = shellEscape(sessionName)
         let conf = shellEscape(configPath)
         // -L uses a dedicated socket, -f uses our minimal config
-        let base = "\(tmuxPath) -L \(socketName) -f \(conf) new-session -A -s \(escaped)"
+        let envFlags = environmentVars.map { "-e \(shellEscape("\($0.key)=\($0.value)"))" }.joined(separator: " ")
+        let base = "\(tmuxPath) -L \(socketName) -f \(conf) new-session -A -s \(escaped) \(envFlags)"
         let wrappedCommand: String
         if let command {
             let escapedCommand = shellEscape(command)

--- a/Sources/Views/EnvironmentTabView.swift
+++ b/Sources/Views/EnvironmentTabView.swift
@@ -239,7 +239,7 @@ struct EnvironmentTabView: View {
     private func buildCommand(script: String, role: String) -> String {
         if useTmux, let tmuxPath = appEnv.toolStatus.tmux.path {
             let session = TmuxSession.sessionName(project: projectName, workstream: workstreamName, role: role)
-            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: script)
+            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: script, environmentVars: environmentVars)
         }
         return script
     }

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -225,7 +225,7 @@ struct TerminalContainerView: View {
 
         if useTmux, let tmuxPath = appEnv.toolStatus.tmux.path {
             let session = TmuxSession.sessionName(project: projectName, workstream: workstreamName, role: "agent")
-            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: cmd)
+            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: cmd, environmentVars: envVars)
         }
         return cmd
     }
@@ -580,7 +580,7 @@ struct TerminalContainerView: View {
     private func buildEnvironmentCommand(script: String, role: String) -> String {
         if useTmux, let tmuxPath = appEnv.toolStatus.tmux.path {
             let session = TmuxSession.sessionName(project: projectName, workstream: workstreamName, role: role)
-            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: script)
+            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: script, environmentVars: envVars)
         }
         return script
     }


### PR DESCRIPTION
## Summary
- Tmux sessions don't inherit the ghostty terminal's environment because the tmux server captures its environment at startup, not from the client shell
- Pass FF_* variables explicitly using tmux's `-e VAR=val` flag on `new-session`
- Fixes `FF_PROJECT_DIR: unbound variable` in setup/run scripts when tmux mode is enabled

## Test plan
- [x] Release build with tmux enabled: setup script receives FF_PROJECT_DIR
- [x] Release build without tmux: already worked
- [x] Debug build: already worked

🤖 Generated with [Claude Code](https://claude.com/claude-code)