### PR TITLE
perf(ci): cache SPM packages between builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Install dependencies
         run: brew install xcodegen zig
 
+      - name: Cache SPM packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/derived/SourcePackages
+          key: spm-${{ hashFiles('FactoryFloor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'project.yml') }}
+          restore-keys: spm-
+
       - name: Cache Ghostty xcframework
         id: ghostty-cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Cache SPM resolved packages (Sentry, swift-cmark) between builds
- Combined with ghostty xcframework caching, should reduce cached builds from ~18min to ~7min

## Test plan
- [ ] First build populates SPM cache
- [ ] Subsequent builds skip package resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)