### PR TITLE
fix(ci): correct xcodegen setup action name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: xcodegen/setup-xcodegen@v1
+      - uses: irgendwie/setup-xcodegen@v1
 
       - uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/test-ghostty.yml
+++ b/.github/workflows/test-ghostty.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: xcodegen/setup-xcodegen@v1
+      - uses: irgendwie/setup-xcodegen@v1
 
       - uses: mlugg/setup-zig@v2
         with:


### PR DESCRIPTION
## Summary
- Fix action name: `xcodegen/setup-xcodegen` doesn't exist, use `irgendwie/setup-xcodegen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)