### PR TITLE
fix(ci): use correct xcodegen action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: irgendwie/setup-xcodegen@v1
+      - uses: xavierLowmiller/xcodegen-action@v1
+        with:
+          install: true
+          run: false
 
       - uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/test-ghostty.yml
+++ b/.github/workflows/test-ghostty.yml
@@ -18,7 +18,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: irgendwie/setup-xcodegen@v1
+      - uses: xavierLowmiller/xcodegen-action@v1
+        with:
+          install: true
+          run: false
 
       - uses: mlugg/setup-zig@v2
         with:


### PR DESCRIPTION
## Summary
- Use `xavierLowmiller/xcodegen-action@v1` (the actual existing action)
- Previous attempts with `xcodegen/setup-xcodegen` and `irgendwie/setup-xcodegen` both failed (repos don't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)