### PR TITLE
fix(ci): use correct xcodegen-action version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: xavierLowmiller/xcodegen-action@v1
+      - uses: xavierLowmiller/xcodegen-action@1.2.4
         with:
           install: true
           run: false

--- a/.github/workflows/test-ghostty.yml
+++ b/.github/workflows/test-ghostty.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: xavierLowmiller/xcodegen-action@v1
+      - uses: xavierLowmiller/xcodegen-action@1.2.4
         with:
           install: true
           run: false


### PR DESCRIPTION
## Summary
- Tags don't use `v` prefix. Use `@1.2.4` instead of `@v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)