### PR TITLE
fix: use os_log Logger with public privacy for debug logging (#43)

### DIFF
--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -2,6 +2,9 @@
 // ABOUTME: Shared across the app as an environment object with async background updates.
 
 import SwiftUI
+import OSLog
+
+private let logger = Logger(subsystem: "factoryfloor", category: "environment")
 
 @MainActor
 final class AppEnvironment: ObservableObject {
@@ -113,7 +116,7 @@ final class AppEnvironment: ObservableObject {
                 var isDir: ObjCBool = false
                 let exists = FileManager.default.fileExists(atPath: project.directory, isDirectory: &isDir) && isDir.boolValue
                 if !exists {
-                    NSLog("[FF] refreshPathValidity: project \(project.name) directory MISSING: \(project.directory)")
+                    logger.warning("[FF] refreshPathValidity: project \(project.name, privacy: .public) directory MISSING: \(project.directory, privacy: .public)")
                     missing.insert(project.id)
                 }
 

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -2,6 +2,9 @@
 // ABOUTME: Handles repo detection, init, worktree create/remove, and repo info.
 
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "factoryfloor", category: "git")
 
 struct GitRepoInfo: Sendable {
     let isRepo: Bool
@@ -230,7 +233,7 @@ enum GitOperations {
 
     private static func run(args: [String], in directory: String) -> String? {
         guard let gitPath else {
-            NSLog("[FF] git run: gitPath is nil")
+            logger.warning("[FF] git run: gitPath is nil")
             return nil
         }
         let process = Process()
@@ -247,13 +250,13 @@ enum GitOperations {
             let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
             let errStr = String(data: errData, encoding: .utf8) ?? ""
             guard process.terminationStatus == 0 else {
-                NSLog("[FF] git \(args.joined(separator: " ")) failed (exit \(process.terminationStatus)): \(errStr)")
+                logger.warning("[FF] git \(args.joined(separator: " "), privacy: .public) failed (exit \(process.terminationStatus, privacy: .public)): \(errStr, privacy: .public)")
                 return nil
             }
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             return String(data: data, encoding: .utf8)
         } catch {
-            NSLog("[FF] git \(args.joined(separator: " ")) threw: \(error)")
+            logger.warning("[FF] git \(args.joined(separator: " "), privacy: .public) threw: \(error, privacy: .public)")
             return nil
         }
     }

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -27,17 +27,17 @@ struct ContentView: View {
 
     private var activeProject: Project? {
         guard let selection else {
-            NSLog("[FF] activeProject: selection is nil")
+            logger.warning("[FF] activeProject: selection is nil")
             return nil
         }
         switch selection {
         case .project(let id):
             let found = projects.first(where: { $0.id == id })
-            if found == nil { NSLog("[FF] activeProject: project \(id) not found in \(projects.count) projects") }
+            if found == nil { logger.warning("[FF] activeProject: project \(id, privacy: .public) not found in \(projects.count, privacy: .public) projects") }
             return found
         case .workstream(let wsID):
             let found = projects.first(where: { $0.workstreams.contains(where: { $0.id == wsID }) })
-            if found == nil { NSLog("[FF] activeProject: workstream \(wsID) not found in any project") }
+            if found == nil { logger.warning("[FF] activeProject: workstream \(wsID, privacy: .public) not found in any project") }
             return found
         case .settings, .help:
             return nil
@@ -227,9 +227,9 @@ struct ContentView: View {
         }
         .onChange(of: appEnvironment.missingProjectIDs) { _, missing in
             guard !missing.isEmpty else { return }
-            NSLog("[FF] missingProjectIDs changed: \(missing.count) missing, \(projects.count) total projects")
+            logger.warning("[FF] missingProjectIDs changed: \(missing.count, privacy: .public) missing, \(projects.count, privacy: .public) total projects")
             let names = projects.filter { missing.contains($0.id) }.map(\.name)
-            NSLog("[FF] removing projects: \(names)")
+            logger.warning("[FF] removing projects: \(names, privacy: .public)")
             for id in missing {
                 if let project = projects.first(where: { $0.id == id }) {
                     for ws in project.workstreams {
@@ -248,7 +248,7 @@ struct ContentView: View {
             removedProjectNames = names
         }
         .onChange(of: selection) { oldValue, newValue in
-            NSLog("[FF] selection changed: \(String(describing: oldValue)) -> \(String(describing: newValue))")
+            logger.warning("[FF] selection changed: \(String(describing: oldValue), privacy: .public) -> \(String(describing: newValue), privacy: .public)")
             if newValue == .settings || newValue == .help {
                 selectionBeforeSettings = oldValue
             }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -3,6 +3,9 @@
 
 import SwiftUI
 import UniformTypeIdentifiers
+import OSLog
+
+private let logger = Logger(subsystem: "factoryfloor", category: "sidebar")
 
 extension Notification.Name {
     static let addProject = Notification.Name("factoryfloor.addProject")
@@ -86,7 +89,7 @@ struct ProjectSidebar: View {
                                 }
                             }
                         } : nil,
-                        onAdd: { NSLog("[FF] onAdd button tapped for project \(project.name)"); addWorkstream(for: project.id) },
+                        onAdd: { logger.warning("[FF] onAdd button tapped for project \(project.name, privacy: .public)"); addWorkstream(for: project.id) },
                         onAddWithPermissions: { addWorkstream(for: project.id, bypassPermissions: true) },
                         onAddWithoutPermissions: { addWorkstream(for: project.id, bypassPermissions: false) },
                         onDelete: { projectToDelete = project.id }
@@ -312,24 +315,24 @@ struct ProjectSidebar: View {
     @AppStorage("factoryfloor.symlinkEnv") private var symlinkEnv: Bool = true
 
     private func addWorkstream(for projectID: UUID, bypassPermissions: Bool? = nil) {
-        NSLog("[FF] addWorkstream called for projectID=\(projectID)")
+        logger.warning("[FF] addWorkstream called for projectID=\(projectID, privacy: .public)")
         guard let index = projects.firstIndex(where: { $0.id == projectID }) else {
-            NSLog("[FF] addWorkstream: project not found")
+            logger.warning("[FF] addWorkstream: project not found")
             return
         }
         let project = projects[index]
-        NSLog("[FF] addWorkstream: project=\(project.name) dir=\(project.directory)")
+        logger.warning("[FF] addWorkstream: project=\(project.name, privacy: .public) dir=\(project.directory, privacy: .public)")
 
         guard GitOperations.isGitRepo(at: project.directory) else {
-            NSLog("[FF] addWorkstream: not a git repo")
+            logger.warning("[FF] addWorkstream: not a git repo")
             showNotGitRepoError = true
             return
         }
-        NSLog("[FF] addWorkstream: is git repo")
+        logger.warning("[FF] addWorkstream: is git repo")
 
         let existingNames = Set(project.workstreams.map(\.name))
         let name = NameGenerator.generate(avoiding: existingNames)
-        NSLog("[FF] addWorkstream: generated name=\(name)")
+        logger.warning("[FF] addWorkstream: generated name=\(name, privacy: .public)")
 
         guard let worktreePath = GitOperations.createWorktree(
             projectPath: project.directory,
@@ -338,11 +341,11 @@ struct ProjectSidebar: View {
             branchPrefix: branchPrefix,
             symlinkEnv: symlinkEnv
         ) else {
-            NSLog("[FF] addWorkstream: createWorktree FAILED")
+            logger.warning("[FF] addWorkstream: createWorktree FAILED")
             showWorktreeError = true
             return
         }
-        NSLog("[FF] addWorkstream: worktree created at \(worktreePath)")
+        logger.warning("[FF] addWorkstream: worktree created at \(worktreePath, privacy: .public)")
 
         let bypass = bypassPermissions ?? defaultBypass
         let workstream = Workstream(name: name, worktreePath: worktreePath, bypassPermissions: bypass)
@@ -351,7 +354,7 @@ struct ProjectSidebar: View {
         expandedProjects.insert(projectID)
         selection = .workstream(workstream.id)
         onProjectsChanged()
-        NSLog("[FF] addWorkstream: done")
+        logger.warning("[FF] addWorkstream: done")
     }
 
     @EnvironmentObject private var surfaceCache: TerminalSurfaceCache


### PR DESCRIPTION
## Summary
NSLog string interpolations were showing as `<private>` in Console.app for Release builds. Switched to `Logger` framework with `privacy: .public` on all interpolated values.

## Test plan
- [ ] Install DMG, open Console.app, filter by "Factory Floor", try adding workspace
- [ ] [FF] log lines should now be readable (not redacted as `<private>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)