### PR TITLE
fix(ci): add actions:write permission for website deploy trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: macos-15
     permissions:
       contents: write
+      actions: write
     env:
       SIGNING_IDENTITY: "Developer ID Application: ALL TUNER LABS S.L. (J5TAY75Q3F)"
       APP_NAME: "Factory Floor"
@@ -252,6 +253,7 @@ jobs:
           fi
 
       - name: Trigger website deploy
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Add `actions: write` permission to build job for `gh workflow run`
- Add `continue-on-error: true` so deploy trigger failure doesn't block the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)