### PR TITLE
fix: defer workstream selection to let @Binding propagate (#43)

### DIFF
--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -352,8 +352,13 @@ struct ProjectSidebar: View {
         projects[index].workstreams.append(workstream)
         rebuildIndices()
         expandedProjects.insert(projectID)
-        selection = .workstream(workstream.id)
         onProjectsChanged()
+        // Defer selection to next run loop so the @Binding mutation propagates
+        // to ContentView's @State before activeProject is evaluated.
+        let wsID = workstream.id
+        DispatchQueue.main.async {
+            selection = .workstream(wsID)
+        }
         logger.warning("[FF] addWorkstream: done")
     }
 


### PR DESCRIPTION
## Summary
Root cause found via production logging: `addWorkstream` mutates `projects` via `@Binding` and immediately sets `selection = .workstream(id)`. In Release builds, SwiftUI evaluates `activeProject` before the binding mutation propagates to ContentView's `@State`, so the new workstream isn't found and the onboarding view shows.

Fix: defer `selection` change to the next run loop with `DispatchQueue.main.async` so the binding write commits first.

## Evidence from logs
```
[FF] addWorkstream: worktree created at ...fixup-warm-edge
[FF] addWorkstream: done
[FF] activeProject: workstream 808C1B68... not found in any project  <-- binding not propagated yet
[FF] selection changed: ... -> workstream(808C1B68...)
```

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)