### PR TITLE
fix: use atomic callbacks for project and workstream creation (#43)

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -165,7 +165,19 @@ struct ContentView: View {
             ProjectSidebar(
                 projects: $projects,
                 selection: $selection,
-                onProjectsChanged: { ProjectStore.save(projects) }
+                onProjectsChanged: { ProjectStore.save(projects) },
+                onWorkstreamAdded: { projectID, workstream in
+                    if let index = projects.firstIndex(where: { $0.id == projectID }) {
+                        projects[index].workstreams.append(workstream)
+                        selection = .workstream(workstream.id)
+                        ProjectStore.save(projects)
+                    }
+                },
+                onProjectAdded: { project in
+                    projects.append(project)
+                    selection = .project(project.id)
+                    ProjectStore.save(projects)
+                }
             )
             .navigationSplitViewColumnWidth(min: 160, ideal: 200, max: 350)
         } detail: {

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -16,6 +16,8 @@ struct ProjectSidebar: View {
     @Binding var projects: [Project]
     @Binding var selection: SidebarSelection?
     let onProjectsChanged: () -> Void
+    var onWorkstreamAdded: ((UUID, Workstream) -> Void)?
+    var onProjectAdded: ((Project) -> Void)?
 
     @State private var showingAddProjectChoice = false
     @State private var showingNewProjectName = false
@@ -349,15 +351,16 @@ struct ProjectSidebar: View {
 
         let bypass = bypassPermissions ?? defaultBypass
         let workstream = Workstream(name: name, worktreePath: worktreePath, bypassPermissions: bypass)
-        projects[index].workstreams.append(workstream)
-        rebuildIndices()
         expandedProjects.insert(projectID)
-        onProjectsChanged()
-        // Defer selection to next run loop so the @Binding mutation propagates
-        // to ContentView's @State before activeProject is evaluated.
-        let wsID = workstream.id
-        DispatchQueue.main.async {
-            selection = .workstream(wsID)
+        if let onWorkstreamAdded {
+            // Let ContentView mutate @State and set selection atomically
+            onWorkstreamAdded(projectID, workstream)
+            rebuildIndices()
+        } else {
+            projects[index].workstreams.append(workstream)
+            rebuildIndices()
+            selection = .workstream(workstream.id)
+            onProjectsChanged()
         }
         logger.warning("[FF] addWorkstream: done")
     }
@@ -474,9 +477,13 @@ struct ProjectSidebar: View {
 
         let projectName = name.isEmpty ? URL(fileURLWithPath: directory).lastPathComponent : name
         let project = Project(name: projectName, directory: directory)
-        projects.append(project)
-        selection = .project(project.id)
-        onProjectsChanged()
+        if let onProjectAdded {
+            onProjectAdded(project)
+        } else {
+            projects.append(project)
+            selection = .project(project.id)
+            onProjectsChanged()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
The DispatchQueue.main.async approach was not sufficient - the binding still didn't propagate in time. 

New approach: `onWorkstreamAdded` and `onProjectAdded` callbacks let ContentView mutate its own `@State var projects` and set `selection` in the same update cycle. This guarantees `activeProject` finds the new item when SwiftUI re-evaluates.

Also fixes the crash when dragging a project to an empty sidebar (same root cause).

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)