### PR TITLE
fix: delay selection after projects mutation (#43)

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -169,14 +169,20 @@ struct ContentView: View {
                 onWorkstreamAdded: { projectID, workstream in
                     if let index = projects.firstIndex(where: { $0.id == projectID }) {
                         projects[index].workstreams.append(workstream)
-                        selection = .workstream(workstream.id)
                         ProjectStore.save(projects)
+                        let wsID = workstream.id
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                            selection = .workstream(wsID)
+                        }
                     }
                 },
                 onProjectAdded: { project in
                     projects.append(project)
-                    selection = .project(project.id)
                     ProjectStore.save(projects)
+                    let pid = project.id
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        selection = .project(pid)
+                    }
                 }
             )
             .navigationSplitViewColumnWidth(min: 160, ideal: 200, max: 350)


### PR DESCRIPTION
## Summary
Even with atomic callbacks mutating @State directly in ContentView, SwiftUI (on Xcode 16.4 / CI runner) re-evaluates `activeProject` between the `projects` mutation and `selection` change. Delay selection by 50ms so the projects change is fully committed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)