### PR TITLE
fix(ci): match local/CI build environments, improve SPM cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Log build environment
+        run: |
+          xcodebuild -version
+          swift --version
+
       - uses: xavierLowmiller/xcodegen-action@1.2.4
         with:
           install: true
@@ -94,6 +99,7 @@ jobs:
         run: |
           xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Release \
             -derivedDataPath build/derived \
+            -clonedSourcePackagesDirPath build/derived/SourcePackages \
             DEVELOPMENT_TEAM=J5TAY75Q3F \
             CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
             CODE_SIGN_STYLE=Manual \

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -35,9 +35,29 @@ case "${1:-build}" in
     xcodegen generate
     xcodebuild -project "$PROJECT" -scheme "$TEST_SCHEME" -configuration Debug test
     ;;
+  release)
+    # Build a Release binary matching CI conditions (hardened runtime, no debug entitlements)
+    BUILD_DIR="build/release-local/derived"
+    xcodegen generate
+    xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Release \
+      -derivedDataPath "$BUILD_DIR" \
+      CODE_SIGN_IDENTITY="-" \
+      CODE_SIGN_STYLE=Manual \
+      ENABLE_HARDENED_RUNTIME=YES \
+      CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+      OTHER_CODE_SIGN_FLAGS="--options=runtime" \
+      build
+    echo "==> Release build at: $BUILD_DIR/Build/Products/Release/Factory Floor.app"
+    if [ "${2:-}" = "--run" ]; then
+      pkill -f "Factory Floor.app/Contents/MacOS/Factory Floor" 2>/dev/null || true
+      sleep 0.5
+      open "$BUILD_DIR/Build/Products/Release/Factory Floor.app"
+    fi
+    ;;
   clean)
     xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Debug clean 2>/dev/null || true
     rm -rf ~/Library/Developer/Xcode/DerivedData/FactoryFloor-*
+    rm -rf build/release-local
     ;;
   *)
     echo "Usage: ./scripts/dev.sh [command] [directory]"
@@ -46,6 +66,8 @@ case "${1:-build}" in
     echo "  run      Kill and relaunch (optionally with a directory)"
     echo "  br       Build and run"
     echo "  test     Run tests"
+    echo "  release  Build Release matching CI (hardened runtime)"
+    echo "  release --run  Build and run Release"
     echo "  clean    Clean build artifacts"
     ;;
 esac


### PR DESCRIPTION
## Summary
- Add `./scripts/dev.sh release [--run]` to build locally with same flags as CI
- Log Xcode/Swift versions in CI for environment traceability
- Use `-clonedSourcePackagesDirPath` for more reliable SPM package caching
- Document in CLAUDE.md

Closes #59
Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)