### PR TITLE
fix: remove double shell-escaping of tmux -e env flags

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -54,7 +54,8 @@ enum TmuxSession {
         let escaped = shellEscape(sessionName)
         let conf = shellEscape(configPath)
         // -L uses a dedicated socket, -f uses our minimal config
-        let envFlags = environmentVars.map { "-e \(shellEscape("\($0.key)=\($0.value)"))" }.joined(separator: " ")
+        // Don't shellEscape env flags here; they'll be escaped by the outer sh -c wrapper
+        let envFlags = environmentVars.map { "-e \($0.key)=\($0.value)" }.joined(separator: " ")
         let base = "\(tmuxPath) -L \(socketName) -f \(conf) new-session -A -s \(escaped) \(envFlags)"
         let wrappedCommand: String
         if let command {


### PR DESCRIPTION
## Summary
The tmux `-e KEY=VALUE` flags were wrapped in `shellEscape()` (single quotes), then the entire command was wrapped again in `shellEscape()` by the outer `sh -c`. This caused nested quote escaping that printed the command to the terminal instead of executing it.

Fix: don't escape the `-e` values individually since they're already inside the outer shell escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)