### PR TITLE
fix: migrate project storage from JSON files to UserDefaults (#46)

### DIFF
--- a/Sources/Models/SidebarSelection.swift
+++ b/Sources/Models/SidebarSelection.swift
@@ -26,68 +26,55 @@ enum SidebarSelection: Hashable, Codable, Sendable {
 
     private static let userDefaultsKey = "factoryfloor.selection"
 
-    private static var fileURL: URL {
+    private static var legacyFileURL: URL {
         AppConstants.configDirectory.appendingPathComponent("sidebar-selection.json")
     }
 
     static func loadSaved() -> SidebarSelection? {
-        // Try loading from JSON file first
-        if let data = try? Data(contentsOf: fileURL) {
-            return try? JSONDecoder().decode(SidebarSelection.self, from: data)
-        }
-        // Migrate from UserDefaults if file doesn't exist
         if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
            let selection = try? JSONDecoder().decode(SidebarSelection.self, from: data) {
+            return selection
+        }
+        // Migrate from JSON file if UserDefaults is empty
+        if let data = try? Data(contentsOf: legacyFileURL),
+           let selection = try? JSONDecoder().decode(SidebarSelection.self, from: data) {
             selection.save()
-            UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+            try? FileManager.default.removeItem(at: legacyFileURL)
             return selection
         }
         return nil
     }
 
     func save() {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(self) else { return }
-        do {
-            try FilePersistence.writeAtomically(data, to: Self.fileURL)
-        } catch {
-            logger.warning("Failed to save sidebar selection: \(error.localizedDescription)")
-        }
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
     }
 }
 
 enum SidebarState {
     private static let userDefaultsKey = "factoryfloor.expandedProjects"
 
-    private static var fileURL: URL {
+    private static var legacyFileURL: URL {
         AppConstants.configDirectory.appendingPathComponent("sidebar-state.json")
     }
 
     static func loadExpanded() -> Set<UUID> {
-        // Try loading from JSON file first
-        if let data = try? Data(contentsOf: fileURL),
+        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
            let ids = try? JSONDecoder().decode(Set<UUID>.self, from: data) {
             return ids
         }
-        // Migrate from UserDefaults if file doesn't exist
-        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+        // Migrate from JSON file if UserDefaults is empty
+        if let data = try? Data(contentsOf: legacyFileURL),
            let ids = try? JSONDecoder().decode(Set<UUID>.self, from: data) {
             saveExpanded(ids)
-            UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+            try? FileManager.default.removeItem(at: legacyFileURL)
             return ids
         }
         return []
     }
 
     static func saveExpanded(_ ids: Set<UUID>) {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(ids) else { return }
-        do {
-            try FilePersistence.writeAtomically(data, to: fileURL)
-        } catch {
-            logger.warning("Failed to save sidebar state: \(error.localizedDescription)")
-        }
+        guard let data = try? JSONEncoder().encode(ids) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
     }
 }

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -394,33 +394,27 @@ struct ContentView: View {
 enum ProjectStore {
     private static let userDefaultsKey = "factoryfloor.projects"
 
-    private static var fileURL: URL {
+    private static var legacyFileURL: URL {
         AppConstants.configDirectory.appendingPathComponent("projects.json")
     }
 
     static func load() -> [Project] {
-        // Try loading from JSON file first
-        if let data = try? Data(contentsOf: fileURL) {
-            return (try? JSONDecoder().decode([Project].self, from: data)) ?? []
-        }
-        // Migrate from UserDefaults if file doesn't exist
         if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
            let projects = try? JSONDecoder().decode([Project].self, from: data) {
+            return projects
+        }
+        // Migrate from JSON file if UserDefaults is empty
+        if let data = try? Data(contentsOf: legacyFileURL),
+           let projects = try? JSONDecoder().decode([Project].self, from: data) {
             save(projects)
-            UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+            try? FileManager.default.removeItem(at: legacyFileURL)
             return projects
         }
         return []
     }
 
     static func save(_ projects: [Project]) {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(projects) else { return }
-        do {
-            try FilePersistence.writeAtomically(data, to: fileURL)
-        } catch {
-            logger.warning("Failed to save projects: \(error.localizedDescription)")
-        }
+        guard let data = try? JSONEncoder().encode(projects) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
     }
 }

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -45,29 +45,36 @@ enum RestorableWorkspaceTab: String, Codable, Sendable {
 }
 
 enum WorkspaceStateStore {
-    private static var fileURL: URL {
+    private static let userDefaultsKey = "factoryfloor.workspaceTabs"
+
+    private static var legacyFileURL: URL {
         AppConstants.configDirectory.appendingPathComponent("workspace-tabs.json")
     }
 
     static func load(for workstreamID: UUID) -> RestorableWorkspaceTab? {
-        guard let data = try? Data(contentsOf: fileURL),
-              let saved = try? JSONDecoder().decode([String: RestorableWorkspaceTab].self, from: data) else {
-            return nil
+        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+           let saved = try? JSONDecoder().decode([String: RestorableWorkspaceTab].self, from: data) {
+            return saved[workstreamID.uuidString]
         }
-        return saved[workstreamID.uuidString]
+        // Migrate from JSON file if UserDefaults is empty
+        if let data = try? Data(contentsOf: legacyFileURL),
+           let saved = try? JSONDecoder().decode([String: RestorableWorkspaceTab].self, from: data) {
+            UserDefaults.standard.set(data, forKey: userDefaultsKey)
+            try? FileManager.default.removeItem(at: legacyFileURL)
+            return saved[workstreamID.uuidString]
+        }
+        return nil
     }
 
     static func save(_ tab: RestorableWorkspaceTab, for workstreamID: UUID) {
         var saved: [String: RestorableWorkspaceTab] = [:]
-        if let data = try? Data(contentsOf: fileURL),
+        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
            let existing = try? JSONDecoder().decode([String: RestorableWorkspaceTab].self, from: data) {
             saved = existing
         }
         saved[workstreamID.uuidString] = tab
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(saved) else { return }
-        try? FilePersistence.writeAtomically(data, to: fileURL)
+        guard let data = try? JSONEncoder().encode(saved) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
     }
 }
 


### PR DESCRIPTION
## Summary
Migrate 4 persistence stores from JSON files to UserDefaults:
- ProjectStore, SidebarSelection, SidebarState, WorkspaceStateStore
- Auto-migrates from legacy JSON on first load
- RunStateStore stays file-based (IPC with ff-run)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)