### PR TITLE
fix: double-quote tmux -e values (#94)

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -54,8 +54,7 @@ enum TmuxSession {
         let escaped = shellEscape(sessionName)
         let conf = shellEscape(configPath)
         // -L uses a dedicated socket, -f uses our minimal config
-        // Don't shellEscape env flags here; they'll be escaped by the outer sh -c wrapper
-        let envFlags = environmentVars.map { "-e \($0.key)=\($0.value)" }.joined(separator: " ")
+        let envFlags = environmentVars.map { "-e \"\($0.key)=\(doubleQuoteEscape($0.value))\"" }.joined(separator: " ")
         let base = "\(tmuxPath) -L \(socketName) -f \(conf) new-session -A -s \(escaped) \(envFlags)"
         let wrappedCommand: String
         if let command {
@@ -107,6 +106,14 @@ enum TmuxSession {
 
     private static func shellEscape(_ str: String) -> String {
         "'\(str.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    /// Escape a string for safe embedding inside double quotes in a shell command.
+    private static func doubleQuoteEscape(_ str: String) -> String {
+        str.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "`", with: "\\`")
     }
 
     private static func serverSetupCommand(tmuxPath: String, configPath: String) -> String {

--- a/Tests/TmuxSessionTests.swift
+++ b/Tests/TmuxSessionTests.swift
@@ -1,8 +1,8 @@
 // ABOUTME: Tests for tmux session configuration and command composition.
 // ABOUTME: Verifies the generated config preserves finished panes instead of respawning them.
 
-import XCTest
 @testable import FactoryFloor
+import XCTest
 
 final class TmuxSessionTests: XCTestCase {
     func testConfigKeepsNativeMouseSelectionEnabled() {
@@ -23,6 +23,30 @@ final class TmuxSessionTests: XCTestCase {
         XCTAssertFalse(TmuxSession.configContents.contains("respawn-pane"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit on"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit-format \"\""))
+    }
+
+    func testWrapCommandQuotesEnvVarValuesWithSpaces() {
+        let command = TmuxSession.wrapCommand(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            sessionName: "proj/ws/agent",
+            command: "echo hello",
+            environmentVars: ["FF_PROJECT": "My Project"]
+        )
+
+        // The value must be double-quoted so the shell keeps it as one token
+        XCTAssertTrue(command.contains("-e \"FF_PROJECT=My Project\""))
+    }
+
+    func testWrapCommandQuotesEnvVarValuesWithSpecialChars() {
+        let command = TmuxSession.wrapCommand(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            sessionName: "proj/ws/agent",
+            command: "echo hello",
+            environmentVars: ["FF_PROJECT": "client's \"best\" $project"]
+        )
+
+        // Single quotes, double quotes, and dollar signs must survive
+        XCTAssertTrue(command.contains("-e \"FF_PROJECT=client's \\\"best\\\" \\$project\""))
     }
 
     func testWrapCommandClearsStalePaneDiedHookBeforeAttaching() {


### PR DESCRIPTION
Closes #94