### PR TITLE
Remove repo-level FUNDING.yml to inherit org-wide default

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: alltuner
-buy_me_a_coffee: alltuner


### PR DESCRIPTION
## Summary
- Remove the repo-level `.github/FUNDING.yml` so this repo inherits the org-wide default from `alltuner/.github`
- The org default includes GitHub Sponsors, Buy Me a Coffee, and the custom alltuner.com/sponsor/ link

🤖 Generated with [Claude Code](https://claude.com/claude-code)