### PR TITLE
feat: display app version on welcome screen

### DIFF
--- a/.hooks/worktree-create.sh
+++ b/.hooks/worktree-create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Symlink build artifacts that aren't tracked in git but are needed for compilation.
+set -euo pipefail
+
+: "${WORKTREE_DIR:?WORKTREE_DIR must be set}"
+: "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR must be set}"
+
+# Ghostty xcframework (built with zig, not in git)
+XCFW_SRC="$CLAUDE_PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework"
+XCFW_DST="$WORKTREE_DIR/ghostty/macos/GhosttyKit.xcframework"
+
+if [ -d "$XCFW_SRC" ] && [ ! -e "$XCFW_DST" ]; then
+    ln -sfn "$XCFW_SRC" "$XCFW_DST"
+fi

--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -52,7 +52,7 @@ struct FF2App: App {
             options.enableAppHangTracking = true
             options.appHangTimeoutInterval = 5
             options.sendDefaultPii = false
-            options.releaseName = "\(AppConstants.appID)@\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0")"
+            options.releaseName = "\(AppConstants.appID)@\(AppConstants.version)"
             #if DEBUG
                 options.environment = "development"
             #else

--- a/Sources/Models/AppConstants.swift
+++ b/Sources/Models/AppConstants.swift
@@ -25,14 +25,26 @@ func resolvedConfigDirectory(
 
 enum AppConstants {
     #if DEBUG
-    static let appID = "factoryfloor-debug"
-    static let appName = "Factory Floor Debug"
-    static let urlScheme = "factoryfloor-debug"
+        static let appID = "factoryfloor-debug"
+        static let appName = "Factory Floor Debug"
+        static let urlScheme = "factoryfloor-debug"
     #else
-    static let appID = "factoryfloor"
-    static let appName = "Factory Floor"
-    static let urlScheme = "factoryfloor"
+        static let appID = "factoryfloor"
+        static let appName = "Factory Floor"
+        static let urlScheme = "factoryfloor"
     #endif
+
+    static var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    static var displayVersion: String {
+        #if DEBUG
+            return "\(version) (Debug)"
+        #else
+            return version
+        #endif
+    }
 
     /// Config directory: ~/.config/factoryfloor/ (respects XDG_CONFIG_HOME).
     /// XCTest uses ~/.config/factoryfloor-tests/ to keep test data isolated.

--- a/Sources/Models/UpdateChecker.swift
+++ b/Sources/Models/UpdateChecker.swift
@@ -13,7 +13,7 @@ class UpdateChecker: ObservableObject {
     private static let versionsURL = URL(string: "https://factory-floor.com/versions.json")!
 
     init() {
-        currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        currentVersion = AppConstants.version
     }
 
     func check() {
@@ -37,7 +37,7 @@ class UpdateChecker: ObservableObject {
     nonisolated static func isNewer(_ remote: String, than local: String) -> Bool {
         let r = remote.split(separator: ".").compactMap { Int($0) }
         let l = local.split(separator: ".").compactMap { Int($0) }
-        for i in 0..<max(r.count, l.count) {
+        for i in 0 ..< max(r.count, l.count) {
             let rv = i < r.count ? r[i] : 0
             let lv = i < l.count ? l[i] : 0
             if rv > lv { return true }

--- a/Sources/Views/HelpView.swift
+++ b/Sources/Views/HelpView.swift
@@ -20,7 +20,7 @@ struct HelpView: View {
                         .frame(width: 128, height: 128)
                     Text(AppConstants.appName)
                         .font(.system(size: 28, weight: .bold))
-                    Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0")")
+                    Text("Version \(AppConstants.displayVersion)")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     (Text("Made with ") + Text("\u{2764}\u{FE0F}") + Text(" in Poblenou, Barcelona"))

--- a/Sources/Views/OnboardingView.swift
+++ b/Sources/Views/OnboardingView.swift
@@ -20,6 +20,9 @@ struct OnboardingView: View {
                     Text("AI-powered workspaces for your codebase.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+                    Text("Version \(AppConstants.displayVersion)")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                 }
                 .padding(.top, 24)
 


### PR DESCRIPTION
## Summary
- Display app version on the onboarding/welcome screen (closes #124)
- Centralize version access in `AppConstants.version` and `AppConstants.displayVersion`
- Debug builds now show "(Debug)" suffix in all version displays
- Add `.hooks/worktree-create.sh` project hook to symlink Ghostty xcframework in worktrees

## Test plan
- [x] Build succeeds
- [x] Existing tests pass (2 pre-existing TmuxSession failures unrelated)
- [ ] Verify version appears on welcome screen when no projects configured
- [ ] Verify "(Debug)" suffix shows in debug builds on both welcome and help screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)