### PR TITLE
feat: resolve git worktree paths to main repository when adding projects

### DIFF
--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -6,7 +6,7 @@ import OSLog
 
 private let logger = Logger(subsystem: "factoryfloor", category: "git")
 
-struct GitRepoInfo: Sendable {
+struct GitRepoInfo {
     let isRepo: Bool
     let branch: String?
     let remoteURL: String?
@@ -14,13 +14,15 @@ struct GitRepoInfo: Sendable {
     let isDirty: Bool
 }
 
-struct WorktreeInfo: Identifiable, Sendable {
+struct WorktreeInfo: Identifiable {
     let path: String
     let branch: String?
     let isDirty: Bool
     let isMain: Bool
 
-    var id: String { path }
+    var id: String {
+        path
+    }
 }
 
 enum GitOperations {
@@ -137,7 +139,8 @@ enum GitOperations {
             // Skip sources that are themselves symlinks to prevent exposing arbitrary files
             if let attrs = try? fm.attributesOfItem(atPath: source.path),
                let fileType = attrs[.type] as? FileAttributeType,
-               fileType != .typeRegular {
+               fileType != .typeRegular
+            {
                 continue
             }
             guard !fm.fileExists(atPath: destination.path) else { continue }
@@ -217,6 +220,35 @@ enum GitOperations {
         // Clean up stale entries
         _ = run(args: ["worktree", "prune"], in: projectPath)
         return pruned
+    }
+
+    /// If the given path is a git worktree (not the main repository), return the main
+    /// repository path. Returns nil for non-git directories or main repositories.
+    static func mainRepositoryPath(for path: String) -> String? {
+        let gitEntry = URL(fileURLWithPath: path).appendingPathComponent(".git")
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: gitEntry.path, isDirectory: &isDir) else {
+            return nil
+        }
+        // .git is a directory in main repos, a file in worktrees
+        guard !isDir.boolValue else {
+            return nil
+        }
+
+        guard let commonDir = run(args: ["rev-parse", "--git-common-dir"], in: path)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            return nil
+        }
+
+        let commonURL: URL
+        if commonDir.hasPrefix("/") {
+            commonURL = URL(fileURLWithPath: commonDir)
+        } else {
+            commonURL = URL(fileURLWithPath: path).appendingPathComponent(commonDir).standardized
+        }
+
+        return commonURL.deletingLastPathComponent().standardizedFileURL.path
     }
 
     // MARK: - Private

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -472,13 +472,24 @@ struct ProjectSidebar: View {
     }
 
     private func addProject(name: String, directory: String) {
-        if let existing = projects.first(where: { $0.directory == directory }) {
+        // Resolve worktree branches to their main repository
+        let resolvedDirectory: String
+        let resolvedName: String
+        if let mainRepoPath = GitOperations.mainRepositoryPath(for: directory) {
+            resolvedDirectory = mainRepoPath
+            resolvedName = URL(fileURLWithPath: mainRepoPath).lastPathComponent
+        } else {
+            resolvedDirectory = directory
+            resolvedName = name
+        }
+
+        if let existing = projects.first(where: { $0.directory == resolvedDirectory }) {
             selection = .project(existing.id)
             return
         }
 
-        let projectName = name.isEmpty ? URL(fileURLWithPath: directory).lastPathComponent : name
-        let project = Project(name: projectName, directory: directory)
+        let projectName = resolvedName.isEmpty ? URL(fileURLWithPath: resolvedDirectory).lastPathComponent : resolvedName
+        let project = Project(name: projectName, directory: resolvedDirectory)
         NotificationCenter.default.post(
             name: .projectCreated,
             object: nil,

--- a/Tests/GitOperationsTests.swift
+++ b/Tests/GitOperationsTests.swift
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for GitOperations worktree resolution.
+// ABOUTME: Validates detection of worktree directories and resolution to main repository.
+
+@testable import FactoryFloor
+import XCTest
+
+final class GitOperationsTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - mainRepositoryPath
+
+    func testMainRepositoryPathReturnsNilForNonGitDirectory() throws {
+        let plainDir = tempDir.appendingPathComponent("plain")
+        try FileManager.default.createDirectory(at: plainDir, withIntermediateDirectories: true)
+
+        XCTAssertNil(GitOperations.mainRepositoryPath(for: plainDir.path))
+    }
+
+    func testMainRepositoryPathReturnsNilForMainRepo() throws {
+        let repoDir = tempDir.appendingPathComponent("main-repo")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init"], in: repoDir)
+
+        XCTAssertNil(GitOperations.mainRepositoryPath(for: repoDir.path))
+    }
+
+    func testMainRepositoryPathResolvesWorktreeToMainRepo() throws {
+        let repoDir = tempDir.appendingPathComponent("main-repo")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        let worktreeDir = tempDir.appendingPathComponent("worktree-branch")
+        git(["worktree", "add", "-b", "test-branch", worktreeDir.path], in: repoDir)
+
+        let result = GitOperations.mainRepositoryPath(for: worktreeDir.path)
+        XCTAssertEqual(
+            URL(fileURLWithPath: result ?? "").standardizedFileURL.path,
+            repoDir.standardizedFileURL.path
+        )
+    }
+
+    func testMainRepositoryPathReturnsNilForNestedDirectoryInWorktree() throws {
+        let repoDir = tempDir.appendingPathComponent("main-repo")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        let worktreeDir = tempDir.appendingPathComponent("worktree-branch")
+        git(["worktree", "add", "-b", "test-branch", worktreeDir.path], in: repoDir)
+
+        // A subdirectory inside the worktree doesn't have its own .git file
+        let subDir = worktreeDir.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        XCTAssertNil(GitOperations.mainRepositoryPath(for: subDir.path))
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func git(_ args: [String], in dir: URL) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = dir
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+}


### PR DESCRIPTION
## Summary
- When a user drags/adds a directory that is a git worktree branch, the app now detects this and adds the main repository instead
- Adds `GitOperations.mainRepositoryPath(for:)` which checks if `.git` is a file (worktree indicator) and resolves the main repo via `git rev-parse --git-common-dir`
- Covers all three add-project entry points (drag-and-drop, file picker, URL scheme) since they all converge on `addProject()`

## Test plan
- [x] Unit tests for `mainRepositoryPath`: non-git dir, main repo, worktree resolution, nested subdirectory
- [ ] Manual: drag a worktree directory into the sidebar, verify the main repo is added
- [ ] Manual: drag a worktree of an already-added project, verify it selects the existing project

🤖 Generated with [Claude Code](https://claude.com/claude-code)