### PR TITLE
fix: align CFBundleVersion with semver so Sparkle detects updates

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleVersion</key>
-    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <!-- x-release-please-start-version -->
+    <string>0.1.30</string>
+    <!-- x-release-please-end -->
     <key>CFBundleShortVersionString</key>
     <!-- x-release-please-start-version -->
     <string>0.1.30</string>
@@ -31,7 +33,7 @@
     <key>SUFeedURL</key>
     <string>https://github.com/alltuner/factoryfloor/releases/latest/download/appcast.xml</string>
     <key>SUEnableAutomaticChecks</key>
-    <false/>
+    <true/>
     <key>CFBundleURLTypes</key>
     <array>
         <dict>

--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -91,6 +91,7 @@ struct FF2App: App {
     var body: some Scene {
         Window(AppConstants.appName, id: "main") {
             ContentView()
+                .environmentObject(updater)
                 .onAppear {
                     if let dir = Self.launchDirectory {
                         DispatchQueue.main.async {

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
     @StateObject private var surfaceCache = TerminalSurfaceCache()
     @StateObject private var appEnvironment = AppEnvironment()
     @StateObject private var updateChecker = UpdateChecker()
+    @EnvironmentObject private var updater: Updater
     @State private var saveWork: DispatchWorkItem?
     @State private var workstreamToArchive: UUID?
     @State private var archiveWarningDirty = false
@@ -194,6 +195,7 @@ struct ContentView: View {
         .environmentObject(surfaceCache)
         .environmentObject(appEnvironment)
         .environmentObject(updateChecker)
+        .environmentObject(updater)
         .onAppear {
             appEnvironment.refresh()
             appEnvironment.refreshAllRepoInfo(projects: projects)

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -145,7 +145,7 @@ struct ProjectSidebar: View {
                 // Bottom bar (always visible)
                 VStack(spacing: 4) {
                     if let version = updateChecker.availableVersion {
-                        UpdateBanner(version: version)
+                        UpdateBanner(version: version, updater: updater)
                     }
 
                     // Credit
@@ -369,6 +369,7 @@ struct ProjectSidebar: View {
     @EnvironmentObject private var surfaceCache: TerminalSurfaceCache
     @EnvironmentObject private var appEnv: AppEnvironment
     @EnvironmentObject private var updateChecker: UpdateChecker
+    @EnvironmentObject private var updater: Updater
 
     private func confirmArchive(_ workstream: Workstream) {
         if let path = workstream.worktreePath, GitOperations.hasUncommittedChanges(at: path) {
@@ -717,6 +718,7 @@ private struct SidebarBottomButton: View {
 
 private struct UpdateBanner: View {
     let version: String
+    @ObservedObject var updater: Updater
 
     @State private var isHovering = false
 
@@ -728,7 +730,11 @@ private struct UpdateBanner: View {
 
     var body: some View {
         Button {
-            NSWorkspace.shared.open(getURL)
+            if updater.canCheckForUpdates {
+                updater.checkForUpdates()
+            } else {
+                NSWorkspace.shared.open(getURL)
+            }
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "arrow.up.circle.fill")

--- a/project.yml
+++ b/project.yml
@@ -16,7 +16,7 @@ settings:
     MACOSX_DEPLOYMENT_TARGET: "14.0"
     CODE_SIGN_IDENTITY: "-"
     CODE_SIGNING_REQUIRED: "NO"
-    CURRENT_PROJECT_VERSION: "1"
+
 
 packages:
   swift-cmark:


### PR DESCRIPTION
## Summary
- CFBundleVersion was hardcoded to `"1"` via `CURRENT_PROJECT_VERSION`, causing Sparkle to think the running app was newer than any semver release (0 < 1). Fixed by using the release-please-managed semver string for both `CFBundleVersion` and `CFBundleShortVersionString`.
- Enabled `SUEnableAutomaticChecks` so Sparkle checks for updates in the background.
- Sidebar update banner now triggers Sparkle directly for DMG users, falling back to the website for Homebrew users.

## Test plan
- [ ] Verify `CFBundleVersion` in built app matches semver string
- [ ] Verify Sparkle "Check for Updates" detects newer versions correctly
- [ ] Verify sidebar banner triggers Sparkle dialog (not browser) on DMG installs
- [ ] Verify Homebrew installs still open `/get` from sidebar banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)