### PR TITLE
fix: upload dSYMs to Sentry for crash symbolication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,16 @@ jobs:
             OTHER_CODE_SIGN_FLAGS="--timestamp --options=runtime" \
             build
 
+      - name: Upload debug symbols to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | sh
+          sentry-cli --url https://de.sentry.io debug-files upload \
+            --org all-tuner-labs \
+            --project factory-floor \
+            build/derived/Build/Products/Release/
+
       - name: Inject Sparkle public key
         env:
           SPARKLE_PUBLIC_KEY: ${{ secrets.SPARKLE_PUBLIC_KEY }}

--- a/project.yml
+++ b/project.yml
@@ -86,6 +86,7 @@ targets:
           PRODUCT_BUNDLE_IDENTIFIER: com.alltuner.factoryfloor
           PRODUCT_NAME: Factory Floor
           FF_URL_SCHEME: factoryfloor
+          DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
     dependencies:
       - target: FFRun
       - package: swift-cmark

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,6 +33,17 @@ rm -rf "$APP_PATH"
 mkdir -p "$BUILD_DIR"
 cp -R "$APP_BUILT" "$APP_PATH"
 
+echo "==> Uploading debug symbols to Sentry..."
+if command -v sentry-cli &>/dev/null; then
+  sentry-cli --url https://de.sentry.io debug-files upload \
+    --org all-tuner-labs \
+    --project factory-floor \
+    "$BUILD_DIR/derived/Build/Products/Release/"
+else
+  echo "Warning: sentry-cli not found, skipping dSYM upload"
+  echo "Install with: brew install getsentry/tools/sentry-cli"
+fi
+
 echo "==> Verifying signature..."
 codesign --verify --verbose=2 "$APP_PATH"
 spctl --assess --type execute --verbose=2 "$APP_PATH" 2>&1


### PR DESCRIPTION
## Summary
- Adds `sentry-cli debug-files upload` to the CI release workflow and local release script so crash stacktraces in Sentry show our actual function names instead of `<unknown>`
- Explicitly sets `DEBUG_INFORMATION_FORMAT: dwarf-with-dsym` in project.yml for Release builds
- Uses the DE region URL (`https://de.sentry.io`) matching the project's Sentry org

## Prerequisites
- `SENTRY_AUTH_TOKEN` secret must be added to GitHub Actions

## Test plan
- [ ] Verify `SENTRY_AUTH_TOKEN` secret exists in repo settings (or add it)
- [ ] Merge and let release-please create the next release
- [ ] After release build, confirm dSYMs appear in Sentry under Settings > Debug Files
- [ ] Trigger a test crash and verify the stacktrace is symbolicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)