### PR TITLE
fix(ci): make dSYM upload non-blocking for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,14 @@ jobs:
             build
 
       - name: Upload debug symbols to Sentry
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "::warning::SENTRY_AUTH_TOKEN not set, skipping dSYM upload"
+            exit 0
+          fi
           curl -sL https://sentry.io/get-cli/ | sh
           sentry-cli --url https://de.sentry.io debug-files upload \
             --org all-tuner-labs \


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` so a failed upload doesn't gate the release
- Checks for `SENTRY_AUTH_TOKEN` before attempting upload, emits a warning if missing

## Test plan
- [ ] Verify release workflow succeeds even if Sentry upload fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)