### PR TITLE
fix: run setup/run/teardown scripts in user's login shell

### DIFF
--- a/Sources/Models/CommandBuilder.swift
+++ b/Sources/Models/CommandBuilder.swift
@@ -39,9 +39,13 @@ struct CommandBuilder {
         return "sh -c \(shellQuote("\(primary) 2>/dev/null || \(fallbackCmd)"))"
     }
 
+    static var userShell: String {
+        ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+    }
+
     static func shellQuote(_ s: String) -> String {
         let simple = !s.isEmpty && s.allSatisfy {
-            $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" || $0 == "." || $0 == "/" || $0 == ":" || $0 == "~" || $0 == "@" || $0 == "+"  || $0 == "="
+            $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" || $0 == "." || $0 == "/" || $0 == ":" || $0 == "~" || $0 == "@" || $0 == "+" || $0 == "="
         }
         if simple { return s }
         return "'\(s.replacingOccurrences(of: "'", with: "'\\''"))'"

--- a/Sources/Models/RunLauncher.swift
+++ b/Sources/Models/RunLauncher.swift
@@ -21,9 +21,9 @@ enum RunLauncher {
     }
 }
 
-func runScriptCommand(script: String, workstreamID: UUID, launcherPath: String) -> String {
+func runScriptCommand(script: String, workstreamID: UUID, launcherPath: String, shell: String = CommandBuilder.userShell) -> String {
     let workstream = workstreamID.uuidString.lowercased()
     let quotedLauncher = CommandBuilder.shellQuote(launcherPath)
     let quotedScript = CommandBuilder.shellQuote(script)
-    return "\(quotedLauncher) --workstream-id \(workstream) -- /bin/sh -lc \(quotedScript)"
+    return "\(quotedLauncher) --workstream-id \(workstream) -- \(shell) -lic \(quotedScript)"
 }

--- a/Sources/Models/ScriptConfig.swift
+++ b/Sources/Models/ScriptConfig.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-struct ScriptConfig: Sendable {
+struct ScriptConfig {
     let setup: String?
     let run: String?
     let teardown: String?
@@ -27,8 +27,8 @@ struct ScriptConfig: Sendable {
         let config = load(from: projectDirectory)
         guard let teardown = config.teardown else { return }
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", teardown]
+        process.executableURL = URL(fileURLWithPath: CommandBuilder.userShell)
+        process.arguments = ["-lc", teardown]
         process.currentDirectoryURL = URL(fileURLWithPath: directory)
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
@@ -52,7 +52,8 @@ struct ScriptConfig: Sendable {
 
     private static func loadJSON(_ path: String) -> [String: Any]? {
         guard let data = FileManager.default.contents(atPath: path),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
             return nil
         }
         return json

--- a/Sources/Views/EnvironmentTabView.swift
+++ b/Sources/Views/EnvironmentTabView.swift
@@ -7,11 +7,14 @@ func shouldRestoreRunSession(useTmux: Bool, hasRunScript: Bool, hasExistingRunSe
     useTmux && hasRunScript && hasExistingRunSession && !wasStoppedManually
 }
 
-func scriptCommand(script: String, role: String) -> String {
+func scriptCommand(script: String, role: String, shell: String = CommandBuilder.userShell) -> String {
+    let inner: String
     if role == "setup" {
-        return "\(script); printf '\\nSetup completed in this terminal.\\n'"
+        inner = "\(script); printf '\\nSetup completed in this terminal.\\n'"
+    } else {
+        inner = script
     }
-    return script
+    return "\(shell) -lic \(CommandBuilder.shellQuote(inner))"
 }
 
 struct EnvironmentTabView: View {

--- a/Tests/EnvironmentTabViewTests.swift
+++ b/Tests/EnvironmentTabViewTests.swift
@@ -1,8 +1,8 @@
 // ABOUTME: Tests for environment tab session restoration decisions.
 // ABOUTME: Verifies run panes reappear when tmux already has a persisted run session.
 
-import XCTest
 @testable import FactoryFloor
+import XCTest
 
 final class EnvironmentTabViewTests: XCTestCase {
     func testRunSessionRestoresOnlyWhenTmuxSessionExists() {
@@ -17,15 +17,35 @@ final class EnvironmentTabViewTests: XCTestCase {
     }
 
     func testSetupScriptAppendsCompletionMessage() {
-        let command = scriptCommand(script: "./.hooks/factoryfloor-setup.sh", role: "setup")
+        let command = scriptCommand(script: "./.hooks/factoryfloor-setup.sh", role: "setup", shell: "/bin/zsh")
 
         XCTAssertTrue(command.contains("./.hooks/factoryfloor-setup.sh"))
         XCTAssertTrue(command.contains("Setup completed in this terminal."))
     }
 
     func testRunScriptDoesNotAppendCompletionMessage() {
-        let command = scriptCommand(script: "just local", role: "run")
+        let command = scriptCommand(script: "just local", role: "run", shell: "/bin/zsh")
 
-        XCTAssertEqual(command, "just local")
+        XCTAssertFalse(command.contains("Setup completed"))
+    }
+
+    func testSetupScriptWrapsInLoginShell() {
+        let command = scriptCommand(script: "setup.sh", role: "setup", shell: "/bin/zsh")
+
+        XCTAssertTrue(command.hasPrefix("/bin/zsh -lic "))
+    }
+
+    func testRunScriptWrapsInLoginShell() {
+        let command = scriptCommand(script: "just local", role: "run", shell: "/bin/zsh")
+
+        XCTAssertTrue(command.hasPrefix("/bin/zsh -lic "))
+        XCTAssertTrue(command.contains("just local"))
+    }
+
+    func testRunScriptCommandUsesLoginShell() {
+        let command = runScriptCommand(script: "bun dev", workstreamID: UUID(), launcherPath: "/path/to/ff-run", shell: "/bin/zsh")
+
+        XCTAssertTrue(command.contains("/bin/zsh -lic"))
+        XCTAssertFalse(command.contains("/bin/sh"))
     }
 }

--- a/Tests/PortDetectionTests.swift
+++ b/Tests/PortDetectionTests.swift
@@ -1,22 +1,23 @@
 // ABOUTME: Tests for run-script port detection and browser retargeting behavior.
 // ABOUTME: Covers launcher command building, port selection stabilization, and browser navigation policy.
 
-import XCTest
 @testable import FactoryFloor
+import XCTest
 
 final class PortDetectionTests: XCTestCase {
-    func testRunLauncherWrapsRunScriptInShell() {
-        let workstreamID = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+    func testRunLauncherWrapsRunScriptInLoginShell() throws {
+        let workstreamID = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-123456789ABC"))
 
         let command = runScriptCommand(
             script: "just dev",
             workstreamID: workstreamID,
-            launcherPath: "/Applications/Factory Floor.app/Contents/Helpers/ff-run"
+            launcherPath: "/Applications/Factory Floor.app/Contents/Helpers/ff-run",
+            shell: "/bin/zsh"
         )
 
         XCTAssertEqual(
             command,
-            "'/Applications/Factory Floor.app/Contents/Helpers/ff-run' --workstream-id 12345678-1234-1234-1234-123456789abc -- /bin/sh -lc 'just dev'"
+            "'/Applications/Factory Floor.app/Contents/Helpers/ff-run' --workstream-id 12345678-1234-1234-1234-123456789abc -- /bin/zsh -lic 'just dev'"
         )
     }
 


### PR DESCRIPTION
## Summary
- Setup, run, and teardown scripts now execute in the user's login shell (`$SHELL -lic`) instead of bare `/bin/sh -c`, so tools like `bun` and `uv` that add to `~/.zshrc`/`~/.zprofile` are available on PATH
- Teardown (runs without a terminal) uses `-lc` instead of `-lic` to avoid interactive-mode issues without a tty
- Added `CommandBuilder.userShell` to resolve `$SHELL` (falls back to `/bin/zsh`)

## Test plan
- [x] Existing tests updated and passing
- [x] New tests for login shell wrapping in `scriptCommand` and `runScriptCommand`
- [ ] Manual: create a workstream with a setup script that uses `bun`/`uv` and verify commands are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)