### PR TITLE
fix: wrap preloaded setup script in login shell

### DIFF
--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -580,11 +580,12 @@ struct TerminalContainerView: View {
     }
 
     private func buildEnvironmentCommand(script: String, role: String) -> String {
+        let command = scriptCommand(script: script, role: role)
         if useTmux, let tmuxPath = appEnv.toolStatus.tmux.path {
             let session = TmuxSession.sessionName(project: projectName, workstream: workstreamName, role: role)
-            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: script, environmentVars: envVars)
+            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: command, environmentVars: terminalEnvVars)
         }
-        return script
+        return command
     }
 
     /// Env vars for plain terminal tabs. Clears tmux vars to prevent inheritance.


### PR DESCRIPTION
## Summary
- `buildEnvironmentCommand()` passed the raw script string directly to tmux/ghostty, bypassing the `$SHELL -lic` wrapping that `scriptCommand()` provides
- Since `preloadSurfaces()` caches the surface before `EnvironmentTabView` renders, the correctly-wrapped command from `envCommand()` was never used
- This caused setup scripts to run without login shell profiles sourced: `bun`/`uv` missing from PATH in tmux mode, `FF_PROJECT_DIR` unavailable in non-tmux mode

## Test plan
- [x] All 75 existing tests pass
- [ ] Verify setup script in tmux mode sources login profiles (bun/uv available)
- [ ] Verify setup script in non-tmux mode has FF_PROJECT_DIR set

🤖 Generated with [Claude Code](https://claude.com/claude-code)