### PR TITLE
fix(ci): prevent premature website deploy during releases

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - 'website/**'
-      - 'CHANGELOG.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove `CHANGELOG.md` from `deploy-website.yml` path triggers
- When release-please merges, it updates `CHANGELOG.md`, which was triggering a website deploy before the binary build finished
- The release workflow already triggers website deploy explicitly at the end of the build job (after sign, notarize, upload)
- Website still deploys on `website/**` changes as before

## Test plan
- [ ] Verify next release deploys the website only after the binary is uploaded
- [ ] Verify pushing changes to `website/` still triggers a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)