### PR TITLE
refactor(ci): embed Sparkle public key in project.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,13 +133,6 @@ jobs:
             --project factory-floor \
             build/derived/Build/Products/Release/
 
-      - name: Inject Sparkle public key
-        env:
-          SPARKLE_PUBLIC_KEY: ${{ secrets.SPARKLE_PUBLIC_KEY }}
-        run: |
-          APP_BUILT=$(find build/derived -name "${APP_NAME}.app" -type d | head -1)
-          /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_PUBLIC_KEY" "$APP_BUILT/Contents/Info.plist"
-
       - name: Package and sign
         env:
           VERSION: ${{ needs.release-please.outputs.version }}

--- a/project.yml
+++ b/project.yml
@@ -43,7 +43,7 @@ targets:
         NSMainStoryboardFile: ""
         NSPrincipalClass: NSApplication
         LSUIElement: false
-        SUPublicEDKey: ""
+        SUPublicEDKey: "grC1rloxT0gFZ2mQVIuDTZlkNFXwXLZhn9+xs4YGuXo="
         SUFeedURL: https://github.com/alltuner/factoryfloor/releases/latest/download/appcast.xml
         SUEnableAutomaticChecks: true
         CFBundleURLTypes:


### PR DESCRIPTION
## Summary
- Moved the Sparkle Ed25519 public key from a GitHub secret into `project.yml` so XcodeGen bakes it directly into Info.plist at build time
- Removed the PlistBuddy injection step from the release workflow
- The `SPARKLE_PUBLIC_KEY` GitHub secret is no longer referenced and can be removed

## Test plan
- [ ] Verify release workflow still passes (key is now in the built Info.plist without PlistBuddy)
- [ ] Verify Sparkle update check works on a release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)