### PR TITLE
fix: replace blocking runModal calls with async alternatives

### DIFF
--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -27,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let projects = ProjectStore.load()
         let hasWorkstreams = projects.contains { !$0.workstreams.isEmpty }
         guard hasWorkstreams else { return .terminateNow }
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return .terminateNow }
 
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Quit Factory Floor?", comment: "")
@@ -35,7 +36,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.addButton(withTitle: NSLocalizedString("Quit", comment: ""))
         alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
 
-        return alert.runModal() == .alertFirstButtonReturn ? .terminateNow : .terminateCancel
+        alert.beginSheetModal(for: window) { response in
+            NSApp.reply(toApplicationShouldTerminate: response == .alertFirstButtonReturn)
+        }
+        return .terminateLater
     }
 }
 

--- a/Sources/Models/Updater.swift
+++ b/Sources/Models/Updater.swift
@@ -3,25 +3,42 @@
 
 import Sparkle
 
+/// Suppresses modal error alerts from Sparkle update checks.
+/// Errors (e.g. network failures) are silently acknowledged instead of
+/// blocking the main thread with NSAlert.runModal(). (Fixes FACTORY-FLOOR-7)
+private class SilentErrorUserDriver: SPUStandardUserDriver {
+    override func showUpdaterError(_: Error, acknowledgement: @escaping () -> Void) {
+        acknowledgement()
+    }
+}
+
 @MainActor
 final class Updater: ObservableObject {
-    private var controller: SPUStandardUpdaterController?
+    private var updater: SPUUpdater?
 
     init() {
         #if !DEBUG
-            controller = SPUStandardUpdaterController(
-                startingUpdater: true,
-                updaterDelegate: nil,
-                userDriverDelegate: nil
-            )
+            let userDriver = SilentErrorUserDriver(hostBundle: .main, delegate: nil)
+            do {
+                let spuUpdater = try SPUUpdater(
+                    hostBundle: .main,
+                    applicationBundle: .main,
+                    userDriver: userDriver,
+                    delegate: nil
+                )
+                try spuUpdater.start()
+                updater = spuUpdater
+            } catch {
+                // Sparkle failed to initialize; updates won't be available
+            }
         #endif
     }
 
     var canCheckForUpdates: Bool {
-        controller?.updater.canCheckForUpdates ?? false
+        updater?.canCheckForUpdates ?? false
     }
 
     func checkForUpdates() {
-        controller?.checkForUpdates(nil)
+        updater?.checkForUpdates()
     }
 }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -444,8 +444,10 @@ struct ProjectSidebar: View {
         panel.directoryURL = URL(fileURLWithPath: baseDirectory)
         panel.message = NSLocalizedString("Choose a project directory", comment: "")
         panel.prompt = NSLocalizedString("Select", comment: "")
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        addProject(name: url.lastPathComponent, directory: url.path)
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            self.addProject(name: url.lastPathComponent, directory: url.path)
+        }
     }
 
     private func createNewProject() {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -21,15 +21,16 @@ struct SettingsView: View {
     @EnvironmentObject private var appEnv: AppEnvironment
     @State private var showingClearConfirm = false
     #if DEBUG
-    private static let cliName = "ff-debug"
+        private static let cliName = "ff-debug"
     #else
-    private static let cliName = "ff"
+        private static let cliName = "ff"
     #endif
     @State private var cliInstalled = Self.isCliCorrectlyInstalled()
 
     var body: some View {
         Form {
             // MARK: - Environment
+
             Section {
                 ToolRow(
                     name: "claude",
@@ -78,6 +79,7 @@ struct SettingsView: View {
             }
 
             // MARK: - Projects
+
             Section("Projects") {
                 HStack {
                     Text("Base directory")
@@ -93,8 +95,10 @@ struct SettingsView: View {
                         panel.allowsMultipleSelection = false
                         panel.directoryURL = URL(fileURLWithPath: baseDirectory)
                         panel.message = NSLocalizedString("Choose base directory for projects", comment: "")
-                        if panel.runModal() == .OK, let url = panel.url {
-                            baseDirectory = url.path
+                        panel.begin { response in
+                            if response == .OK, let url = panel.url {
+                                baseDirectory = url.path
+                            }
                         }
                     }
                 }
@@ -132,6 +136,7 @@ struct SettingsView: View {
             }
 
             // MARK: - Terminal & Browser
+
             Section("Terminal & Browser") {
                 Toggle("Tmux Mode", isOn: $tmuxMode)
                     .disabled(!appEnv.toolStatus.tmux.isInstalled)
@@ -183,6 +188,7 @@ struct SettingsView: View {
             }
 
             // MARK: - Coding Agent
+
             Section("Coding Agent") {
                 Toggle("Bypass permission prompts", isOn: $bypassPermissions)
                 Text("When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking.")
@@ -201,6 +207,7 @@ struct SettingsView: View {
             }
 
             // MARK: - Appearance
+
             Section("Appearance") {
                 Picker("Theme", selection: $appearance) {
                     Text("System").tag("system")
@@ -228,6 +235,7 @@ struct SettingsView: View {
             }
 
             // MARK: - Danger
+
             Section("Danger Zone") {
                 Toggle("Bleeding edge", isOn: $bleedingEdge)
                 Text("Receive pre-release builds with the latest features. These may be less stable.")
@@ -294,7 +302,8 @@ struct SettingsView: View {
         let fm = FileManager.default
         guard fm.fileExists(atPath: path),
               fm.isExecutableFile(atPath: path),
-              let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+              let contents = try? String(contentsOfFile: path, encoding: .utf8)
+        else {
             return false
         }
         return contents.contains(AppConstants.urlScheme)
@@ -330,7 +339,7 @@ struct SettingsView: View {
 
 // MARK: - Tool Detection
 
-enum BinaryStatus: Sendable {
+enum BinaryStatus {
     case notFound
     case found(String)
 
@@ -340,12 +349,12 @@ enum BinaryStatus: Sendable {
     }
 
     var path: String? {
-        if case .found(let p) = self { return p }
+        if case let .found(p) = self { return p }
         return nil
     }
 }
 
-struct ToolStatus: Sendable {
+struct ToolStatus {
     var tmux: BinaryStatus = .notFound
     var tmuxVersion: String?
     var claude: BinaryStatus = .notFound
@@ -486,7 +495,9 @@ private struct ToolRow: View {
 struct AppInfo: Identifiable, @unchecked Sendable {
     let name: String
     let bundleID: String
-    var id: String { bundleID }
+    var id: String {
+        bundleID
+    }
 
     var icon: NSImage? {
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return nil }
@@ -506,7 +517,7 @@ struct AppInfo: Identifiable, @unchecked Sendable {
             ("Alacritty", "org.alacritty"),
             ("kitty", "net.kovidgoyal.kitty"),
         ]
-        return candidates.compactMap { (name, id) in
+        return candidates.compactMap { name, id in
             isAppInstalled(id) ? AppInfo(name: name, bundleID: id) : nil
         }
     }
@@ -521,7 +532,7 @@ struct AppInfo: Identifiable, @unchecked Sendable {
             ("Microsoft Edge", "com.microsoft.edgemac"),
             ("Opera", "com.operasoftware.Opera"),
         ]
-        return candidates.compactMap { (name, id) in
+        return candidates.compactMap { name, id in
             isAppInstalled(id) ? AppInfo(name: name, bundleID: id) : nil
         }
     }


### PR DESCRIPTION
## Summary
- Sparkle update error alerts silently acknowledged instead of blocking the main thread with `NSAlert.runModal()`, fixing false app-hang reports in Sentry (FACTORY-FLOOR-7)
- Quit confirmation converted from `runModal()` to `beginSheetModal` with `.terminateLater`
- NSOpenPanel calls in ProjectSidebar and SettingsView converted from `runModal()` to async `begin` callbacks

## Test plan
- [ ] Build and run the app
- [ ] Trigger "Check for Updates" with no internet to verify no modal appears
- [ ] Quit with active workstreams to verify sheet-based confirmation works
- [ ] Add a project via directory picker to verify async NSOpenPanel works
- [ ] Change base directory in settings to verify async NSOpenPanel works

🤖 Generated with [Claude Code](https://claude.com/claude-code)