### PR TITLE
fix: host appcast on website to avoid Sparkle update race condition

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -49,11 +49,12 @@ jobs:
             sed '1{/^# Changelog$/d;}' CHANGELOG.md
           } > website/content/changelog.md
 
-      - name: Generate versions.json from release manifest
+      - name: Download appcast.xml from latest release
         working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(jq -r '."."' .release-please-manifest.json)
-          jq -n --arg v "$VERSION" '{"stable":$v,"latest":$v}' > website/static/versions.json
+          gh release download --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output website/static/appcast.xml
 
       - run: hugo
 

--- a/Sources/Models/UpdateChecker.swift
+++ b/Sources/Models/UpdateChecker.swift
@@ -1,5 +1,5 @@
-// ABOUTME: Checks factory-floor.com/versions.json for available updates.
-// ABOUTME: Sidebar badge fallback for Homebrew users; Sparkle handles DMG auto-updates.
+// ABOUTME: Checks factory-floor.com/appcast.xml for available updates.
+// ABOUTME: Sidebar badge for Homebrew users; Sparkle handles DMG auto-updates.
 
 import Foundation
 import os
@@ -10,7 +10,7 @@ class UpdateChecker: ObservableObject {
 
     private let currentVersion: String
     private let logger = Logger(subsystem: AppConstants.appID, category: "UpdateChecker")
-    private static let versionsURL = URL(string: "https://factory-floor.com/versions.json")!
+    private static let appcastURL = URL(string: "https://factory-floor.com/appcast.xml")!
 
     init() {
         currentVersion = AppConstants.version
@@ -19,18 +19,26 @@ class UpdateChecker: ObservableObject {
     func check() {
         Task.detached { [currentVersion, logger] in
             do {
-                let (data, _) = try await URLSession.shared.data(from: Self.versionsURL)
-                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: String],
-                      let stable = json["stable"] else { return }
-                if Self.isNewer(stable, than: currentVersion) {
+                let (data, _) = try await URLSession.shared.data(from: Self.appcastURL)
+                guard let version = Self.parseVersion(from: data) else { return }
+                if Self.isNewer(version, than: currentVersion) {
                     await MainActor.run { [weak self] in
-                        self?.availableVersion = stable
+                        self?.availableVersion = version
                     }
                 }
             } catch {
                 logger.debug("Update check failed: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Extracts the sparkle:shortVersionString from the first enclosure in an appcast feed.
+    nonisolated static func parseVersion(from data: Data) -> String? {
+        let parser = AppcastParser()
+        let xmlParser = XMLParser(data: data)
+        xmlParser.delegate = parser
+        guard xmlParser.parse() else { return nil }
+        return parser.version
     }
 
     /// Simple semver comparison: returns true if `remote` is newer than `local`.
@@ -44,5 +52,21 @@ class UpdateChecker: ObservableObject {
             if rv < lv { return false }
         }
         return false
+    }
+}
+
+private class AppcastParser: NSObject, XMLParserDelegate {
+    var version: String?
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        if elementName == "enclosure", version == nil {
+            version = attributeDict["sparkle:shortVersionString"]
+        }
     }
 }

--- a/Tests/UpdateCheckerTests.swift
+++ b/Tests/UpdateCheckerTests.swift
@@ -1,0 +1,51 @@
+// ABOUTME: Tests for parsing the latest version from a Sparkle appcast XML feed.
+// ABOUTME: Covers valid appcast, missing version, and malformed XML scenarios.
+
+@testable import FactoryFloor
+import XCTest
+
+final class UpdateCheckerTests: XCTestCase {
+    func testParsesVersionFromAppcast() {
+        let xml = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>Version 0.2.0</title>
+              <enclosure url="https://example.com/app.dmg"
+                         sparkle:version="0.2.0"
+                         sparkle:shortVersionString="0.2.0"
+                         length="1000"
+                         type="application/octet-stream" />
+            </item>
+          </channel>
+        </rss>
+        """
+        let version = UpdateChecker.parseVersion(from: Data(xml.utf8))
+        XCTAssertEqual(version, "0.2.0")
+    }
+
+    func testReturnsNilForMissingVersion() {
+        let xml = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+          </channel>
+        </rss>
+        """
+        let version = UpdateChecker.parseVersion(from: Data(xml.utf8))
+        XCTAssertNil(version)
+    }
+
+    func testReturnsNilForMalformedXML() {
+        let version = UpdateChecker.parseVersion(from: Data("not xml".utf8))
+        XCTAssertNil(version)
+    }
+
+    func testIsNewerComparison() {
+        XCTAssertTrue(UpdateChecker.isNewer("0.2.0", than: "0.1.37"))
+        XCTAssertTrue(UpdateChecker.isNewer("0.1.38", than: "0.1.37"))
+        XCTAssertFalse(UpdateChecker.isNewer("0.1.37", than: "0.1.37"))
+        XCTAssertFalse(UpdateChecker.isNewer("0.1.36", than: "0.1.37"))
+    }
+}

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -12,11 +12,11 @@ Factory Floor ships via two channels:
 
 ## Update notification
 
-The app checks `https://factory-floor.com/versions.json` on launch
-and every 6 hours. If a newer stable version exists, a badge appears
-in the sidebar linking to `factory-floor.com/get`.
+DMG users get automatic updates via Sparkle, which reads the appcast
+feed at `https://factory-floor.com/appcast.xml`.
 
-`versions.json` is updated automatically by the release workflow.
+Homebrew users see a sidebar badge when a newer version is available.
+The app parses the version from the same appcast feed.
 
 ## Release flow
 
@@ -31,7 +31,7 @@ in the sidebar linking to `factory-floor.com/get`.
    - Create and sign DMG
    - Upload DMG to GitHub release
    - Update Homebrew cask in `alltuner/homebrew-tap`
-   - Update `versions.json` and trigger website deploy
+   - Trigger website deploy (deploys appcast.xml from the release)
 5. Website deploys automatically (GitHub Pages)
 6. Users see update badge on next app launch
 
@@ -45,18 +45,6 @@ in the sidebar linking to `factory-floor.com/get`.
 | `APPLE_TEAM_ID` | Team identifier |
 | `APPLE_APP_PASSWORD` | App-specific password for notarization |
 | `HOMEBREW_TAP_TOKEN` | PAT with `public_repo` scope for tap updates |
-
-## versions.json
-
-```json
-{
-  "stable": "1.0.0",
-  "latest": "1.0.0"
-}
-```
-
-- `stable`: current release version
-- `latest`: same as stable for now; reserved for future beta channel
 
 ## Local release (manual)
 
@@ -79,6 +67,6 @@ After a release, verify:
 
 1. GitHub release exists with notarized DMG attached
 2. Homebrew cask points to the new DMG
-3. `factory-floor.com/versions.json` reports the new version
+3. `factory-floor.com/appcast.xml` reports the new version
 4. `/get` page shows correct install/upgrade commands
 5. App shows update badge when running an older version

--- a/docs/sparkle-integration.md
+++ b/docs/sparkle-integration.md
@@ -4,12 +4,10 @@ GitHub issue: #39
 
 ## Background
 
-Factory Floor currently notifies users about new versions by polling
-`factory-floor.com/versions.json` and showing a badge in the sidebar
-(see `UpdateChecker.swift`). Users must then manually download the DMG
-from GitHub Releases or run `brew upgrade`. Sparkle replaces this with
-true in-app auto-updates: check, download, verify, and install, all
-without leaving the app.
+Factory Floor notifies Homebrew users about new versions by parsing the
+appcast feed at `factory-floor.com/appcast.xml` and showing a badge in
+the sidebar (see `UpdateChecker.swift`). DMG users get automatic
+updates via Sparkle, which reads the same appcast feed.
 
 [Sparkle](https://sparkle-project.org/) is the standard auto-update
 framework for macOS apps. Both
@@ -74,11 +72,13 @@ pattern ghostty and cmux use).
 | Key | Value | Notes |
 |-----|-------|-------|
 | `SUPublicEDKey` | (empty or placeholder) | Overwritten by CI with real public key |
-| `SUFeedURL` | `https://github.com/alltuner/factoryfloor/releases/latest/download/appcast.xml` | Points to the appcast hosted as a GitHub release asset |
+| `SUFeedURL` | `https://factory-floor.com/appcast.xml` | Points to the appcast hosted on the website |
 | `SUEnableAutomaticChecks` | `false` | Let users opt in via Settings |
 
-Using `releases/latest/download/` means GitHub always redirects to the
-most recent release's `appcast.xml`, so we don't need a separate CDN.
+The appcast is hosted on the website and updated by the deploy workflow
+after each release. This avoids a race condition where the GitHub
+`releases/latest/` redirect points to a new release before assets are
+uploaded.
 
 ### 4. App Code Changes
 
@@ -129,14 +129,11 @@ simplest integration path.
 - Optionally add an "Automatically check for updates" toggle bound to
   `controller.updater.automaticallyChecksForUpdates`.
 
-**Remove or repurpose: `UpdateChecker.swift`**
+**Keep: `UpdateChecker.swift`**
 
-The current `UpdateChecker` that polls `versions.json` becomes
-redundant once Sparkle handles update detection. It can be removed, or
-kept temporarily as a fallback for Homebrew users who won't get Sparkle
-updates (Homebrew replaces the app bundle, so Sparkle's in-app updater
-doesn't apply to them). The sidebar badge could remain for Homebrew
-users, driven by the existing `versions.json` check.
+`UpdateChecker` parses the version from the same `appcast.xml` feed on
+the website. It drives the sidebar badge for Homebrew users who don't
+get Sparkle auto-updates.
 
 ### 5. Codesign Sparkle Frameworks
 
@@ -227,32 +224,11 @@ simplified: we only need one channel and one item (the latest release).
 
 ### 7. Appcast Hosting
 
-**Recommended: GitHub release asset** (same as cmux)
-
-Set `SUFeedURL` to:
-```
-https://github.com/alltuner/factoryfloor/releases/latest/download/appcast.xml
-```
-
-GitHub's `latest/download/` path always redirects to the most recent
-release's assets. This means:
-- No separate hosting infrastructure needed.
-- The appcast is versioned alongside the DMG.
-- Each release gets its own `appcast.xml` with the current version's
-  entry.
-
-**Alternative: CDN (like ghostty)**
-
-Ghostty hosts appcast on `release.files.ghostty.org` (Cloudflare R2)
-and maintains a cumulative appcast with version history. This is more
-complex but supports features like delta updates and version-specific
-minimum OS requirements. Not needed for our scale.
-
-**Alternative: `factory-floor.com/appcast.xml`**
-
-Host on our existing website. Simpler than R2 but requires the website
-deploy workflow to also update the appcast. Adds a coupling between
-release and website deploy that doesn't exist today.
+The appcast is hosted on the website at `factory-floor.com/appcast.xml`.
+The deploy-website workflow downloads the appcast from the latest GitHub
+release and includes it in the static site. This ensures the feed URL
+only updates after assets are fully uploaded, avoiding a race condition
+with the GitHub `releases/latest/` redirect.
 
 ### 8. Appcast Generation Script
 
@@ -320,7 +296,7 @@ and replace the running copy.
 | `Sources/Views/SettingsView.swift` | Add auto-update toggle |
 | `.github/workflows/release.yml` | Setup Sparkle, inject keys, sign frameworks, generate appcast, upload |
 | `scripts/generate_appcast.py` | New: builds appcast.xml from release metadata |
-| `Sources/Models/UpdateChecker.swift` | Remove or keep for Homebrew-only fallback |
+| `Sources/Models/UpdateChecker.swift` | Parse version from appcast.xml instead of versions.json |
 
 ## New GitHub Secrets
 

--- a/project.yml
+++ b/project.yml
@@ -44,7 +44,7 @@ targets:
         NSPrincipalClass: NSApplication
         LSUIElement: false
         SUPublicEDKey: "grC1rloxT0gFZ2mQVIuDTZlkNFXwXLZhn9+xs4YGuXo="
-        SUFeedURL: https://github.com/alltuner/factoryfloor/releases/latest/download/appcast.xml
+        SUFeedURL: https://factory-floor.com/appcast.xml
         SUEnableAutomaticChecks: true
         CFBundleURLTypes:
           - CFBundleURLName: com.alltuner.factoryfloor.open

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 public/
 resources/
 content/changelog.md
-static/versions.json
+static/appcast.xml


### PR DESCRIPTION
## Summary
- Moves Sparkle's `SUFeedURL` from `releases/latest/download/appcast.xml` to `factory-floor.com/appcast.xml`, fixing a race condition where release-please publishes the release (updating the "latest" pointer) before the build job uploads assets
- Replaces `versions.json` with appcast XML parsing in `UpdateChecker` for the Homebrew sidebar badge
- Updates website deploy workflow to download `appcast.xml` from the latest GitHub release instead of generating `versions.json`

## Test plan
- [x] All 79 XCTest tests pass, including new `UpdateCheckerTests` for appcast XML parsing
- [ ] Verify next release deploys appcast.xml to factory-floor.com
- [ ] Verify Sparkle reads the appcast from the new URL without errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)