### PR TITLE
fix: skip symlinks when loading doc files in info panel

### DIFF
--- a/Sources/Views/WorkstreamInfoView.swift
+++ b/Sources/Views/WorkstreamInfoView.swift
@@ -297,10 +297,14 @@ struct DocFile: Identifiable {
     static let standardNames = ["README.md", "CLAUDE.md", "AGENTS.md"]
 
     static func loadFrom(directory: String) -> [DocFile] {
+        let fm = FileManager.default
         var found: [DocFile] = []
         for name in standardNames {
             let path = URL(fileURLWithPath: directory).appendingPathComponent(name).path
-            if let data = FileManager.default.contents(atPath: path),
+            guard let attrs = try? fm.attributesOfItem(atPath: path),
+                  attrs[.type] as? FileAttributeType == .typeRegular
+            else { continue }
+            if let data = fm.contents(atPath: path),
                data.count >= 20,
                let content = String(data: data, encoding: .utf8)
             {


### PR DESCRIPTION
## Summary
- Skip symlinked files (CLAUDE.md, AGENTS.md, README.md) in the workstream info panel
- Only regular files are now displayed; symlinks are filtered out via `attributesOfItem` file-type check

## Test plan
- [ ] Place a symlinked CLAUDE.md in a workstream directory, verify it does not appear in the info panel
- [ ] Verify regular CLAUDE.md/AGENTS.md/README.md files still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)