### PR TITLE
fix: run build in worktree-create hook for SourceKit resolution

### DIFF
--- a/.hooks/worktree-create.sh
+++ b/.hooks/worktree-create.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Symlink build artifacts that aren't tracked in git but are needed for compilation.
+# ABOUTME: Claude Code worktree-create hook for Factory Floor.
+# ABOUTME: Symlinks build artifacts and runs a build so SourceKit resolves symbols.
 set -euo pipefail
 
 : "${WORKTREE_DIR:?WORKTREE_DIR must be set}"
@@ -12,3 +13,8 @@ XCFW_DST="$WORKTREE_DIR/ghostty/macos/GhosttyKit.xcframework"
 if [ -d "$XCFW_SRC" ] && [ ! -e "$XCFW_DST" ]; then
     ln -sfn "$XCFW_SRC" "$XCFW_DST"
 fi
+
+# Build so SourceKit can resolve symbols across files in the worktree.
+# dev.sh runs xcodegen + xcodebuild with the shared SPM cache.
+cd "$WORKTREE_DIR"
+./scripts/dev.sh build


### PR DESCRIPTION
## Summary
- Run `./scripts/dev.sh build` (xcodegen + xcodebuild with shared SPM cache) after worktree creation so SourceKit can resolve symbols across files
- Previously the hook only symlinked the Ghostty xcframework, leaving worktrees without an xcodeproj or build artifacts

Closes #161

## Test plan
- [ ] Create a new worktree with Claude Code and verify SourceKit resolves cross-file types without false diagnostics
- [ ] Verify the build uses the shared SPM cache (no redundant package downloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)