### PR TITLE
fix(website): link changelog versions to GitHub releases

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -46,7 +46,7 @@ jobs:
             echo 'hideInstall: true'
             echo 'translationKey: changelog'
             echo '---'
-            sed '1{/^# Changelog$/d;}' CHANGELOG.md
+            sed -e '1{/^# Changelog$/d;}' -e 's|compare/v[0-9.]*\.\.\.v\([0-9.]*\)|releases/tag/v\1|g' CHANGELOG.md
           } > website/content/changelog.md
 
       - name: Download appcast.xml from latest release


### PR DESCRIPTION
## Summary
- Changelog version headings on the website now link to the GitHub release page instead of the diff between tags
- Achieved with a sed transform in the deploy workflow, so the repo's CHANGELOG.md stays untouched

## Test plan
- [ ] Verify the deployed changelog page has correct links (e.g. `releases/tag/v0.1.40`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)