### PR TITLE
ci: make Ghostty compat test manual-only and arm64-only

### DIFF
--- a/.github/workflows/test-ghostty.yml
+++ b/.github/workflows/test-ghostty.yml
@@ -1,8 +1,6 @@
 name: Test Ghostty Compatibility
 
 on:
-  schedule:
-    - cron: '0 8 * * 1'  # Weekly on Monday at 8am UTC
   workflow_dispatch:
     inputs:
       ghostty_tag:
@@ -43,7 +41,7 @@ jobs:
       - name: Build Ghostty xcframework
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Dxcframework-target=aarch64-macos -Doptimize=ReleaseFast
 
       - name: Build Factory Floor
         run: |


### PR DESCRIPTION
## Summary
- Remove weekly cron schedule from `test-ghostty.yml` (keep `workflow_dispatch` for manual use)
- Switch xcframework build target from `universal` to `aarch64-macos` to avoid upstream Ghostty x86_64 DockTilePlugin compile failure with Xcode 16.4

## Context
The weekly run [failed](https://github.com/alltuner/factoryfloor/actions/runs/23428689145) because Ghostty v1.3.1's DockTilePlugin doesn't compile for x86_64 on Xcode 16.4. The scheduled job isn't useful since we update the submodule intentionally; x86_64 issues would surface in the release workflow.

## Test plan
- [ ] Manual `workflow_dispatch` still available in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)