### PR TITLE
fix: preserve terminal and browser tabs across workspace navigation

### DIFF
--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -100,6 +100,36 @@ enum WorkspaceTab: Hashable {
     }
 }
 
+/// Captured workspace tab state for a workstream, used to survive navigation.
+struct WorkspaceTabSnapshot {
+    var tabs: [WorkspaceTab]
+    var terminalCount: Int
+    var browserCount: Int
+    var activeTab: WorkspaceTab
+    var browserTitles: [UUID: String]
+    var terminalTitles: [UUID: String]
+
+    /// Returns a copy with dead terminal tabs removed.
+    /// Browser tabs are kept regardless (they don't use terminal surfaces).
+    func reconciled(liveSurfaceIDs: Set<UUID>) -> WorkspaceTabSnapshot {
+        let filteredTabs = tabs.filter { tab in
+            if case let .terminal(id) = tab {
+                return liveSurfaceIDs.contains(id)
+            }
+            return true
+        }
+        let resolvedActiveTab = filteredTabs.contains(activeTab) ? activeTab : .agent
+        return WorkspaceTabSnapshot(
+            tabs: filteredTabs,
+            terminalCount: terminalCount,
+            browserCount: browserCount,
+            activeTab: resolvedActiveTab,
+            browserTitles: browserTitles,
+            terminalTitles: terminalTitles
+        )
+    }
+}
+
 enum TerminalSessionMode: Equatable {
     case standard
     case tmux
@@ -376,12 +406,27 @@ struct TerminalContainerView: View {
             cachedClaudeCommand = buildClaudeCommand()
             scriptConfig = ScriptConfig.load(from: projectDirectory)
             surfaceCache.respawnableIDs.insert(claudeID)
-            if scriptConfig.hasAnyScript && !tabs.contains(.environment) {
-                tabs.insert(.environment, at: 2)
+            if let snapshot = surfaceCache.restoreTabSnapshot(for: workstreamID) {
+                tabs = snapshot.tabs
+                terminalCount = snapshot.terminalCount
+                browserCount = snapshot.browserCount
+                activeTab = snapshot.activeTab
+                browserTitles = snapshot.browserTitles
+                terminalTitles = snapshot.terminalTitles
+                if scriptConfig.hasAnyScript && !tabs.contains(.environment) {
+                    tabs.insert(.environment, at: 2)
+                }
+            } else {
+                if scriptConfig.hasAnyScript && !tabs.contains(.environment) {
+                    tabs.insert(.environment, at: 2)
+                }
+                activeTab = restoredActiveTab()
             }
-            activeTab = restoredActiveTab()
             preloadSurfaces()
             surfaceCache.updateOcclusion(visibleSurfaceIDs: visibleSurfaceIDs)
+        }
+        .onDisappear {
+            surfaceCache.saveTabSnapshot(for: workstreamID, snapshot: currentTabSnapshot())
         }
         .onChange(of: activeTab) {
             surfaceCache.updateOcclusion(visibleSurfaceIDs: visibleSurfaceIDs)
@@ -515,6 +560,7 @@ struct TerminalContainerView: View {
         let tab = WorkspaceTab.terminal(id)
         tabs.append(tab)
         activeTab = tab
+        saveTabSnapshot()
     }
 
     private func addBrowser() {
@@ -523,6 +569,7 @@ struct TerminalContainerView: View {
         let tab = WorkspaceTab.browser(id)
         tabs.append(tab)
         activeTab = tab
+        saveTabSnapshot()
     }
 
     private func closeTab(_ tab: WorkspaceTab) {
@@ -537,6 +584,22 @@ struct TerminalContainerView: View {
             let newIndex = min(index, tabs.count - 1)
             activeTab = tabs[newIndex]
         }
+        saveTabSnapshot()
+    }
+
+    private func currentTabSnapshot() -> WorkspaceTabSnapshot {
+        WorkspaceTabSnapshot(
+            tabs: tabs,
+            terminalCount: terminalCount,
+            browserCount: browserCount,
+            activeTab: activeTab,
+            browserTitles: browserTitles,
+            terminalTitles: terminalTitles
+        )
+    }
+
+    private func saveTabSnapshot() {
+        surfaceCache.saveTabSnapshot(for: workstreamID, snapshot: currentTabSnapshot())
     }
 
     private func moveCustomTab(to targetTab: WorkspaceTab) {
@@ -774,6 +837,7 @@ extension Notification.Name {
 final class TerminalSurfaceCache: ObservableObject {
     private var surfaces: [UUID: TerminalView] = [:]
     private var surfaceParams: [UUID: SurfaceParams] = [:]
+    private var tabSnapshots: [UUID: WorkspaceTabSnapshot] = [:]
     /// Surface IDs that should respawn when closed (e.g., the agent).
     var respawnableIDs: Set<UUID> = []
 
@@ -826,6 +890,7 @@ final class TerminalSurfaceCache: ObservableObject {
     }
 
     func removeWorkstreamSurfaces(for workstreamID: UUID) {
+        tabSnapshots.removeValue(forKey: workstreamID)
         // Remove agent surface
         removeSurface(for: workstreamID)
         // Build a set of all possible derived IDs and remove matches
@@ -857,5 +922,21 @@ final class TerminalSurfaceCache: ObservableObject {
             removeSurface(for: id)
             NotificationCenter.default.post(name: .terminalTabExited, object: id)
         }
+    }
+
+    // MARK: - Workspace tab snapshots
+
+    func saveTabSnapshot(for workstreamID: UUID, snapshot: WorkspaceTabSnapshot) {
+        tabSnapshots[workstreamID] = snapshot
+    }
+
+    func restoreTabSnapshot(for workstreamID: UUID) -> WorkspaceTabSnapshot? {
+        guard let snapshot = tabSnapshots[workstreamID] else { return nil }
+        let liveSurfaceIDs = Set(surfaces.keys)
+        return snapshot.reconciled(liveSurfaceIDs: liveSurfaceIDs)
+    }
+
+    func removeTabSnapshot(for workstreamID: UUID) {
+        tabSnapshots.removeValue(forKey: workstreamID)
     }
 }

--- a/Tests/WorkspaceTabStateTests.swift
+++ b/Tests/WorkspaceTabStateTests.swift
@@ -1,8 +1,93 @@
 // ABOUTME: Tests for workspace tab restoration and custom tab reordering.
 // ABOUTME: Verifies only fixed tabs are restored and custom tabs reorder deterministically.
 
-import XCTest
 @testable import FactoryFloor
+import XCTest
+
+final class WorkspaceTabSnapshotTests: XCTestCase {
+    func testSaveAndRestore() {
+        let workstreamID = UUID()
+        let terminalID = derivedUUID(from: workstreamID, salt: "terminal-1")
+        let browserID = derivedUUID(from: workstreamID, salt: "browser-1")
+        let tabs: [WorkspaceTab] = [.info, .agent, .terminal(terminalID), .browser(browserID)]
+
+        let snapshot = WorkspaceTabSnapshot(
+            tabs: tabs,
+            terminalCount: 1,
+            browserCount: 1,
+            activeTab: .terminal(terminalID),
+            browserTitles: [browserID: "localhost"],
+            terminalTitles: [terminalID: "zsh"]
+        )
+
+        XCTAssertEqual(snapshot.tabs, tabs)
+        XCTAssertEqual(snapshot.terminalCount, 1)
+        XCTAssertEqual(snapshot.browserCount, 1)
+        XCTAssertEqual(snapshot.activeTab, .terminal(terminalID))
+        XCTAssertEqual(snapshot.browserTitles[browserID], "localhost")
+        XCTAssertEqual(snapshot.terminalTitles[terminalID], "zsh")
+    }
+
+    func testReconcileFiltersDeadTerminals() {
+        let workstreamID = UUID()
+        let liveTerminalID = derivedUUID(from: workstreamID, salt: "terminal-1")
+        let deadTerminalID = derivedUUID(from: workstreamID, salt: "terminal-2")
+        let browserID = derivedUUID(from: workstreamID, salt: "browser-1")
+
+        let snapshot = WorkspaceTabSnapshot(
+            tabs: [.info, .agent, .terminal(liveTerminalID), .terminal(deadTerminalID), .browser(browserID)],
+            terminalCount: 2,
+            browserCount: 1,
+            activeTab: .terminal(deadTerminalID),
+            browserTitles: [:],
+            terminalTitles: [:]
+        )
+
+        let reconciled = snapshot.reconciled(liveSurfaceIDs: [liveTerminalID])
+
+        XCTAssertEqual(reconciled.tabs, [.info, .agent, .terminal(liveTerminalID), .browser(browserID)])
+        XCTAssertEqual(reconciled.terminalCount, 2) // count preserved for ID generation
+        XCTAssertEqual(reconciled.activeTab, .agent) // fell back since dead terminal was active
+    }
+
+    func testReconcilePreservesActiveTabWhenAlive() {
+        let workstreamID = UUID()
+        let terminalID = derivedUUID(from: workstreamID, salt: "terminal-1")
+
+        let snapshot = WorkspaceTabSnapshot(
+            tabs: [.info, .agent, .terminal(terminalID)],
+            terminalCount: 1,
+            browserCount: 0,
+            activeTab: .terminal(terminalID),
+            browserTitles: [:],
+            terminalTitles: [:]
+        )
+
+        let reconciled = snapshot.reconciled(liveSurfaceIDs: [terminalID])
+
+        XCTAssertEqual(reconciled.tabs, [.info, .agent, .terminal(terminalID)])
+        XCTAssertEqual(reconciled.activeTab, .terminal(terminalID))
+    }
+
+    func testReconcileKeepsBrowserTabsRegardlessOfSurfaces() {
+        let browserID = UUID()
+
+        let snapshot = WorkspaceTabSnapshot(
+            tabs: [.info, .agent, .browser(browserID)],
+            terminalCount: 0,
+            browserCount: 1,
+            activeTab: .browser(browserID),
+            browserTitles: [:],
+            terminalTitles: [:]
+        )
+
+        // Empty live surfaces - browser should still survive
+        let reconciled = snapshot.reconciled(liveSurfaceIDs: [])
+
+        XCTAssertEqual(reconciled.tabs, [.info, .agent, .browser(browserID)])
+        XCTAssertEqual(reconciled.activeTab, .browser(browserID))
+    }
+}
 
 final class WorkspaceTabStateTests: XCTestCase {
     func testCustomTabsPersistAsInfo() {
@@ -15,10 +100,10 @@ final class WorkspaceTabStateTests: XCTestCase {
         XCTAssertEqual(RestorableWorkspaceTab.environment.workspaceTab(hasEnvironmentTab: true), .environment)
     }
 
-    func testReorderedCustomTabsKeepsFixedTabsInPlace() {
-        let terminalA = WorkspaceTab.terminal(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!)
-        let browserB = WorkspaceTab.browser(UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!)
-        let terminalC = WorkspaceTab.terminal(UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!)
+    func testReorderedCustomTabsKeepsFixedTabsInPlace() throws {
+        let terminalA = try WorkspaceTab.terminal(XCTUnwrap(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")))
+        let browserB = try WorkspaceTab.browser(XCTUnwrap(UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")))
+        let terminalC = try WorkspaceTab.terminal(XCTUnwrap(UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")))
         let tabs: [WorkspaceTab] = [.info, .agent, .environment, terminalA, browserB, terminalC]
 
         let reordered = reorderedCustomTabs(tabs, dragging: terminalC, to: terminalA)


### PR DESCRIPTION
## Summary
- Terminal and browser tabs were lost when navigating away from a workstream (switching workstreams, adding projects, etc.) because tab state was `@State` inside `TerminalContainerView`, which gets torn down on navigation
- Adds `WorkspaceTabSnapshot` to capture tab state in `TerminalSurfaceCache` (lives on `ContentView`, survives navigation). Saved on tab mutations and `onDisappear`, restored on `onAppear`
- Dead terminal tabs (shells that exited while navigated away) are filtered out on restore via reconciliation against live surfaces

## Test plan
- [x] Added `WorkspaceTabSnapshotTests` covering save/restore, dead terminal filtering, active tab fallback, and browser tab preservation
- [x] All 83 tests pass
- [ ] Manual: open a workstream, add terminal/browser tabs, switch to another workstream or add a project, switch back — tabs should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)