### PR TITLE
fix: sidebar archive button fails due to stale workstream index cache

### DIFF
--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -205,6 +205,9 @@ struct ProjectSidebar: View {
             cachedSortedIDs = recomputeSortedIDs()
             rebuildIndices()
         }
+        .onChange(of: projects.flatMap(\.workstreams).map(\.id)) { _, _ in
+            rebuildIndices()
+        }
         .overlay {
             if isDropTargeted {
                 RoundedRectangle(cornerRadius: 8)
@@ -382,7 +385,7 @@ struct ProjectSidebar: View {
 
     private func performArchive() {
         guard let wsID = workstreamToArchive,
-              let (pi, _) = cachedWorkstreamIndex[wsID] else { return }
+              let pi = projects.firstIndex(where: { $0.workstreams.contains(where: { $0.id == wsID }) }) else { return }
         let projectID = projects[pi].id
         WorkstreamArchiver.archive(wsID, in: &projects[pi], surfaceCache: surfaceCache, tmuxPath: appEnv.toolStatus.tmux.path)
         rebuildIndices()


### PR DESCRIPTION
## Summary
- Sidebar's `performArchive()` used `cachedWorkstreamIndex` which was never updated when workstreams were added to existing projects (only rebuilt on `onAppear` and project count changes)
- Switched to live `firstIndex(where:)` lookup, matching ContentView's existing approach
- Added `onChange` trigger for workstream ID changes to keep the cache fresh for terminal activity tracking and sidebar expansion

## Test plan
- [ ] Create a workstream, then click the archive button in the sidebar — should show confirmation and archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)