### PR TITLE
fix: add privacy entitlements and TCC usage descriptions for embedded terminal

### DIFF
--- a/Resources/ff2.entitlements
+++ b/Resources/ff2.entitlements
@@ -4,5 +4,19 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <false/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -50,6 +50,21 @@ targets:
           - CFBundleURLName: com.alltuner.factoryfloor.open
             CFBundleURLSchemes:
               - $(FF_URL_SCHEME)
+        NSAppleEventsUsageDescription: A program running within Factory Floor would like to use AppleScript.
+        NSAudioCaptureUsageDescription: A program running within Factory Floor would like to access your system's audio.
+        NSBluetoothAlwaysUsageDescription: A program running within Factory Floor would like to use Bluetooth.
+        NSCalendarsUsageDescription: A program running within Factory Floor would like to access your Calendar.
+        NSCameraUsageDescription: A program running within Factory Floor would like to use the camera.
+        NSContactsUsageDescription: A program running within Factory Floor would like to access your Contacts.
+        NSLocalNetworkUsageDescription: A program running within Factory Floor would like to access the local network.
+        NSLocationTemporaryUsageDescriptionDictionary: A program running within Factory Floor would like to use your location temporarily.
+        NSLocationUsageDescription: A program running within Factory Floor would like to access your location information.
+        NSMicrophoneUsageDescription: A program running within Factory Floor would like to use your microphone.
+        NSMotionUsageDescription: A program running within Factory Floor would like to access motion data.
+        NSPhotoLibraryUsageDescription: A program running within Factory Floor would like to access your Photo Library.
+        NSRemindersUsageDescription: A program running within Factory Floor would like to access your reminders.
+        NSSpeechRecognitionUsageDescription: A program running within Factory Floor would like to use speech recognition.
+        NSSystemAdministrationUsageDescription: A program running within Factory Floor requires elevated privileges.
     sources:
       - path: Sources
         excludes:


### PR DESCRIPTION
## Summary
- Adds `com.apple.security.*` privacy entitlements to `ff2.entitlements` (addressbook, calendars, location, photos-library, camera, audio-input, apple-events) so hardened runtime allows these capabilities
- Adds 15 `NS*UsageDescription` keys to `project.yml` info properties so TCC shows consent prompts instead of silently denying access
- Matches the same set of privacy declarations that standalone Ghostty uses

## Context
CLI tools running inside Factory Floor's embedded terminal were silently denied access to protected macOS resources (Contacts, Calendar, etc.). Two separate macOS gatekeeping mechanisms were involved:
1. **Hardened runtime** blocks capabilities unless declared in entitlements
2. **TCC** silently denies access unless `NS*UsageDescription` keys exist in Info.plist

Factory Floor was missing both. Standalone Ghostty works because it declares both.

Closes #167

## Test plan
- [ ] Build release (`./scripts/dev.sh release --run`)
- [ ] Run a CLI tool that accesses Contacts (e.g., `python3 -c "import subprocess; subprocess.run(['osascript', '-e', 'tell application \"Contacts\" to get name of every person'])"`)
- [ ] Verify macOS shows the consent prompt attributed to Factory Floor
- [ ] Verify the permission works after granting access

🤖 Generated with [Claude Code](https://claude.com/claude-code)