### PR TITLE
feat: localize NS*UsageDescription privacy strings

### DIFF
--- a/Localization/ca.lproj/InfoPlist.strings
+++ b/Localization/ca.lproj/InfoPlist.strings
@@ -1,0 +1,44 @@
+/* Privacy - AppleScript */
+"NSAppleEventsUsageDescription" = "Un programa executant-se dins de Factory Floor voldria utilitzar AppleScript.";
+
+/* Privacy - Audio */
+"NSAudioCaptureUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir a l'àudio del sistema.";
+
+/* Privacy - Bluetooth */
+"NSBluetoothAlwaysUsageDescription" = "Un programa executant-se dins de Factory Floor voldria utilitzar el Bluetooth.";
+
+/* Privacy - Calendars */
+"NSCalendarsUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir al Calendari.";
+
+/* Privacy - Camera */
+"NSCameraUsageDescription" = "Un programa executant-se dins de Factory Floor voldria utilitzar la càmera.";
+
+/* Privacy - Contacts */
+"NSContactsUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir als Contactes.";
+
+/* Privacy - Local Network */
+"NSLocalNetworkUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir a la xarxa local.";
+
+/* Privacy - Location (Temporary) */
+"NSLocationTemporaryUsageDescriptionDictionary" = "Un programa executant-se dins de Factory Floor voldria utilitzar la ubicació temporalment.";
+
+/* Privacy - Location */
+"NSLocationUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir a la informació d'ubicació.";
+
+/* Privacy - Microphone */
+"NSMicrophoneUsageDescription" = "Un programa executant-se dins de Factory Floor voldria utilitzar el micròfon.";
+
+/* Privacy - Motion */
+"NSMotionUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir a les dades de moviment.";
+
+/* Privacy - Photos */
+"NSPhotoLibraryUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir a la Fototeca.";
+
+/* Privacy - Reminders */
+"NSRemindersUsageDescription" = "Un programa executant-se dins de Factory Floor voldria accedir als recordatoris.";
+
+/* Privacy - Speech Recognition */
+"NSSpeechRecognitionUsageDescription" = "Un programa executant-se dins de Factory Floor voldria utilitzar el reconeixement de veu.";
+
+/* Privacy - System Administration */
+"NSSystemAdministrationUsageDescription" = "Un programa executant-se dins de Factory Floor requereix privilegis elevats.";

--- a/Localization/en.lproj/InfoPlist.strings
+++ b/Localization/en.lproj/InfoPlist.strings
@@ -1,0 +1,44 @@
+/* Privacy - AppleScript */
+"NSAppleEventsUsageDescription" = "A program running within Factory Floor would like to use AppleScript.";
+
+/* Privacy - Audio */
+"NSAudioCaptureUsageDescription" = "A program running within Factory Floor would like to access your system's audio.";
+
+/* Privacy - Bluetooth */
+"NSBluetoothAlwaysUsageDescription" = "A program running within Factory Floor would like to use Bluetooth.";
+
+/* Privacy - Calendars */
+"NSCalendarsUsageDescription" = "A program running within Factory Floor would like to access your Calendar.";
+
+/* Privacy - Camera */
+"NSCameraUsageDescription" = "A program running within Factory Floor would like to use the camera.";
+
+/* Privacy - Contacts */
+"NSContactsUsageDescription" = "A program running within Factory Floor would like to access your Contacts.";
+
+/* Privacy - Local Network */
+"NSLocalNetworkUsageDescription" = "A program running within Factory Floor would like to access the local network.";
+
+/* Privacy - Location (Temporary) */
+"NSLocationTemporaryUsageDescriptionDictionary" = "A program running within Factory Floor would like to use your location temporarily.";
+
+/* Privacy - Location */
+"NSLocationUsageDescription" = "A program running within Factory Floor would like to access your location information.";
+
+/* Privacy - Microphone */
+"NSMicrophoneUsageDescription" = "A program running within Factory Floor would like to use your microphone.";
+
+/* Privacy - Motion */
+"NSMotionUsageDescription" = "A program running within Factory Floor would like to access motion data.";
+
+/* Privacy - Photos */
+"NSPhotoLibraryUsageDescription" = "A program running within Factory Floor would like to access your Photo Library.";
+
+/* Privacy - Reminders */
+"NSRemindersUsageDescription" = "A program running within Factory Floor would like to access your reminders.";
+
+/* Privacy - Speech Recognition */
+"NSSpeechRecognitionUsageDescription" = "A program running within Factory Floor would like to use speech recognition.";
+
+/* Privacy - System Administration */
+"NSSystemAdministrationUsageDescription" = "A program running within Factory Floor requires elevated privileges.";

--- a/Localization/es.lproj/InfoPlist.strings
+++ b/Localization/es.lproj/InfoPlist.strings
@@ -1,0 +1,44 @@
+/* Privacy - AppleScript */
+"NSAppleEventsUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere utilizar AppleScript.";
+
+/* Privacy - Audio */
+"NSAudioCaptureUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder al audio del sistema.";
+
+/* Privacy - Bluetooth */
+"NSBluetoothAlwaysUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere utilizar el Bluetooth.";
+
+/* Privacy - Calendars */
+"NSCalendarsUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder al Calendario.";
+
+/* Privacy - Camera */
+"NSCameraUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere utilizar la cámara.";
+
+/* Privacy - Contacts */
+"NSContactsUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder a los Contactos.";
+
+/* Privacy - Local Network */
+"NSLocalNetworkUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder a la red local.";
+
+/* Privacy - Location (Temporary) */
+"NSLocationTemporaryUsageDescriptionDictionary" = "Un programa ejecutándose dentro de Factory Floor quiere utilizar tu ubicación temporalmente.";
+
+/* Privacy - Location */
+"NSLocationUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder a tu información de ubicación.";
+
+/* Privacy - Microphone */
+"NSMicrophoneUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere utilizar el micrófono.";
+
+/* Privacy - Motion */
+"NSMotionUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder a los datos de movimiento.";
+
+/* Privacy - Photos */
+"NSPhotoLibraryUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder a la Fototeca.";
+
+/* Privacy - Reminders */
+"NSRemindersUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere acceder a los recordatorios.";
+
+/* Privacy - Speech Recognition */
+"NSSpeechRecognitionUsageDescription" = "Un programa ejecutándose dentro de Factory Floor quiere utilizar el reconocimiento de voz.";
+
+/* Privacy - System Administration */
+"NSSystemAdministrationUsageDescription" = "Un programa ejecutándose dentro de Factory Floor requiere privilegios elevados.";

--- a/Localization/sv.lproj/InfoPlist.strings
+++ b/Localization/sv.lproj/InfoPlist.strings
@@ -1,0 +1,44 @@
+/* Privacy - AppleScript */
+"NSAppleEventsUsageDescription" = "Ett program som körs i Factory Floor vill använda AppleScript.";
+
+/* Privacy - Audio */
+"NSAudioCaptureUsageDescription" = "Ett program som körs i Factory Floor vill komma åt systemets ljud.";
+
+/* Privacy - Bluetooth */
+"NSBluetoothAlwaysUsageDescription" = "Ett program som körs i Factory Floor vill använda Bluetooth.";
+
+/* Privacy - Calendars */
+"NSCalendarsUsageDescription" = "Ett program som körs i Factory Floor vill komma åt din Kalender.";
+
+/* Privacy - Camera */
+"NSCameraUsageDescription" = "Ett program som körs i Factory Floor vill använda kameran.";
+
+/* Privacy - Contacts */
+"NSContactsUsageDescription" = "Ett program som körs i Factory Floor vill komma åt dina Kontakter.";
+
+/* Privacy - Local Network */
+"NSLocalNetworkUsageDescription" = "Ett program som körs i Factory Floor vill komma åt det lokala nätverket.";
+
+/* Privacy - Location (Temporary) */
+"NSLocationTemporaryUsageDescriptionDictionary" = "Ett program som körs i Factory Floor vill tillfälligt använda din plats.";
+
+/* Privacy - Location */
+"NSLocationUsageDescription" = "Ett program som körs i Factory Floor vill komma åt din platsinformation.";
+
+/* Privacy - Microphone */
+"NSMicrophoneUsageDescription" = "Ett program som körs i Factory Floor vill använda mikrofonen.";
+
+/* Privacy - Motion */
+"NSMotionUsageDescription" = "Ett program som körs i Factory Floor vill komma åt rörelsedata.";
+
+/* Privacy - Photos */
+"NSPhotoLibraryUsageDescription" = "Ett program som körs i Factory Floor vill komma åt ditt Fotobibliotek.";
+
+/* Privacy - Reminders */
+"NSRemindersUsageDescription" = "Ett program som körs i Factory Floor vill komma åt dina påminnelser.";
+
+/* Privacy - Speech Recognition */
+"NSSpeechRecognitionUsageDescription" = "Ett program som körs i Factory Floor vill använda taligenkänning.";
+
+/* Privacy - System Administration */
+"NSSystemAdministrationUsageDescription" = "Ett program som körs i Factory Floor kräver förhöjda behörigheter.";

--- a/project.yml
+++ b/project.yml
@@ -79,6 +79,14 @@ targets:
         buildPhase: resources
       - path: Localization/sv.lproj/Localizable.strings
         buildPhase: resources
+      - path: Localization/en.lproj/InfoPlist.strings
+        buildPhase: resources
+      - path: Localization/ca.lproj/InfoPlist.strings
+        buildPhase: resources
+      - path: Localization/es.lproj/InfoPlist.strings
+        buildPhase: resources
+      - path: Localization/sv.lproj/InfoPlist.strings
+        buildPhase: resources
       - path: Resources/Scripts/ff
         buildPhase: resources
     settings:


### PR DESCRIPTION
## Summary
- Add `InfoPlist.strings` to all 4 locales (en, ca, es, sv) with translated versions of the 15 TCC consent prompt strings
- Register the new files as resources in `project.yml` so XcodeGen includes them in the bundle

Closes #172

## Test plan
- [ ] Run `xcodegen generate` and verify InfoPlist.strings files appear in the Xcode project
- [ ] Build and inspect the app bundle to confirm localized strings are in each `.lproj` directory
- [ ] Change system language to Catalan/Spanish/Swedish and trigger a TCC prompt to verify localized text

🤖 Generated with [Claude Code](https://claude.com/claude-code)