### PR TITLE
fix: cache WKWebView instances to prevent browser tab reload on switch

### DIFF
--- a/Sources/Views/BrowserView.swift
+++ b/Sources/Views/BrowserView.swift
@@ -41,9 +41,9 @@ private func normalizedBrowserURL(_ urlString: String) -> String {
 struct BrowserView: View {
     let defaultURL: String
     var tabID: UUID?
+    let webView: WKWebView
 
     @State private var urlText: String = ""
-    @State private var webView = WKWebView()
     @State private var isLoading = false
     @State private var canGoBack = false
     @State private var canGoForward = false
@@ -141,10 +141,18 @@ struct BrowserView: View {
             }
         }
         .onAppear {
-            urlText = defaultURL
-            navigateTo(defaultURL)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                urlFieldFocused = true
+            if webView.url == nil {
+                urlText = defaultURL
+                navigateTo(defaultURL)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    urlFieldFocused = true
+                }
+            } else {
+                urlText = webView.url?.absoluteString ?? defaultURL
+                canGoBack = webView.canGoBack
+                canGoForward = webView.canGoForward
+                isLoading = webView.isLoading
+                pageTitle = webView.title
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { _ in
@@ -207,7 +215,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         return webView
     }
 
-    func updateNSView(_ nsView: WKWebView, context: Context) {}
+    func updateNSView(_: WKWebView, context _: Context) {}
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -220,31 +228,32 @@ struct WebViewRepresentable: NSViewRepresentable {
             self.parent = parent
         }
 
-        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
             parent.isLoading = true
             parent.connectionError = false
             updateState(webView)
         }
 
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
             parent.isLoading = false
             parent.connectionError = false
             updateState(webView)
         }
 
-        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
             parent.isLoading = false
             updateState(webView)
         }
 
-        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: Error) {
             parent.isLoading = false
             let nsError = error as NSError
             // Connection refused, host not found, network issues
-            if nsError.domain == NSURLErrorDomain &&
+            if nsError.domain == NSURLErrorDomain,
                [NSURLErrorCannotConnectToHost, NSURLErrorCannotFindHost,
                 NSURLErrorNetworkConnectionLost, NSURLErrorNotConnectedToInternet,
-                NSURLErrorTimedOut].contains(nsError.code) {
+                NSURLErrorTimedOut].contains(nsError.code)
+            {
                 parent.connectionError = true
             }
             updateState(webView)

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -2,6 +2,7 @@
 // ABOUTME: Info and Agent are always present; terminals and browsers are added on demand.
 
 import SwiftUI
+import WebKit
 
 extension Notification.Name {
     static let terminalSurfaceClosed = Notification.Name("factoryfloor.terminalSurfaceClosed")
@@ -391,7 +392,7 @@ struct TerminalContainerView: View {
                 environmentVars: terminalEnvVars
             )
         case let .browser(id):
-            BrowserView(defaultURL: browserDefaultURL, tabID: id)
+            BrowserView(defaultURL: browserDefaultURL, tabID: id, webView: surfaceCache.webView(for: id))
                 .id(id)
         }
     }
@@ -575,9 +576,14 @@ struct TerminalContainerView: View {
     private func closeTab(_ tab: WorkspaceTab) {
         guard let index = tabs.firstIndex(of: tab) else { return }
         tabs.remove(at: index)
-        // Clean up terminal surface
-        if case let .terminal(id) = tab {
+        // Clean up cached views
+        switch tab {
+        case let .terminal(id):
             surfaceCache.removeSurface(for: id)
+        case let .browser(id):
+            surfaceCache.removeWebView(for: id)
+        default:
+            break
         }
         // Switch to previous tab or agent
         if activeTab == tab {
@@ -838,6 +844,7 @@ final class TerminalSurfaceCache: ObservableObject {
     private var surfaces: [UUID: TerminalView] = [:]
     private var surfaceParams: [UUID: SurfaceParams] = [:]
     private var tabSnapshots: [UUID: WorkspaceTabSnapshot] = [:]
+    private var webViews: [UUID: WKWebView] = [:]
     /// Surface IDs that should respawn when closed (e.g., the agent).
     var respawnableIDs: Set<UUID> = []
 
@@ -882,6 +889,17 @@ final class TerminalSurfaceCache: ObservableObject {
         return view
     }
 
+    func webView(for id: UUID) -> WKWebView {
+        if let existing = webViews[id] { return existing }
+        let view = WKWebView()
+        webViews[id] = view
+        return view
+    }
+
+    func removeWebView(for id: UUID) {
+        webViews.removeValue(forKey: id)
+    }
+
     func removeSurface(for id: UUID) {
         if let view = surfaces.removeValue(forKey: id) {
             view.destroy()
@@ -900,8 +918,9 @@ final class TerminalSurfaceCache: ObservableObject {
                 derivedIDs.insert(derivedUUID(from: workstreamID, salt: "\(prefix)-\(i)"))
             }
         }
-        for id in derivedIDs where surfaces[id] != nil {
-            removeSurface(for: id)
+        for id in derivedIDs {
+            if surfaces[id] != nil { removeSurface(for: id) }
+            if webViews[id] != nil { removeWebView(for: id) }
         }
     }
 

--- a/Tests/BrowserViewTests.swift
+++ b/Tests/BrowserViewTests.swift
@@ -1,0 +1,41 @@
+// ABOUTME: Tests for browser web view caching in TerminalSurfaceCache.
+// ABOUTME: Verifies cached WKWebView instances are reused across tab switches.
+
+@testable import FactoryFloor
+import WebKit
+import XCTest
+
+@MainActor
+final class BrowserViewTests: XCTestCase {
+    func testWebViewCacheReturnsSameInstance() {
+        let cache = TerminalSurfaceCache()
+        let id = UUID()
+
+        let first = cache.webView(for: id)
+        let second = cache.webView(for: id)
+
+        XCTAssertTrue(first === second, "Cache should return the same WKWebView instance")
+    }
+
+    func testWebViewCacheReturnsDifferentInstancesForDifferentIDs() {
+        let cache = TerminalSurfaceCache()
+        let id1 = UUID()
+        let id2 = UUID()
+
+        let view1 = cache.webView(for: id1)
+        let view2 = cache.webView(for: id2)
+
+        XCTAssertFalse(view1 === view2, "Different IDs should get different WKWebView instances")
+    }
+
+    func testRemoveWebViewClearsCache() {
+        let cache = TerminalSurfaceCache()
+        let id = UUID()
+
+        let first = cache.webView(for: id)
+        cache.removeWebView(for: id)
+        let second = cache.webView(for: id)
+
+        XCTAssertFalse(first === second, "After removal, a new WKWebView instance should be created")
+    }
+}


### PR DESCRIPTION
## Summary
- Browser tabs were reloading every time you switched away and back because `BrowserView` created a new `WKWebView` via `@State` on each SwiftUI reconstruction
- Cache `WKWebView` instances in `TerminalSurfaceCache` (same pattern as terminal surfaces), reuse them across tab switches
- On reappear, restore UI state from the existing web view instead of navigating again

## Test plan
- [x] New `BrowserViewTests` verify cache returns same instance, different IDs get different instances, and removal creates fresh instance
- [x] All 86 tests pass
- [ ] Manual: open a browser tab, navigate to a page, switch to another tab, switch back — page should not reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)