### PR TITLE
security: remove unused entitlements and use ephemeral browser storage

### DIFF
--- a/Resources/ff2.entitlements
+++ b/Resources/ff2.entitlements
@@ -6,17 +6,5 @@
     <false/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.personal-information.addressbook</key>
-    <true/>
-    <key>com.apple.security.personal-information.calendars</key>
-    <true/>
-    <key>com.apple.security.personal-information.location</key>
-    <true/>
-    <key>com.apple.security.personal-information.photos-library</key>
-    <true/>
 </dict>
 </plist>

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -891,7 +891,9 @@ final class TerminalSurfaceCache: ObservableObject {
 
     func webView(for id: UUID) -> WKWebView {
         if let existing = webViews[id] { return existing }
-        let view = WKWebView()
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        let view = WKWebView(frame: .zero, configuration: config)
         webViews[id] = view
         return view
     }


### PR DESCRIPTION
## Summary

Two minimal security hardening changes with zero functional impact.

### 1. Remove unused entitlements

Removes 6 entitlements from `ff2.entitlements` that have no corresponding code usage:

- `device.camera`
- `device.audio-input`
- `personal-information.addressbook`
- `personal-information.calendars`
- `personal-information.location`
- `personal-information.photos-library`

With `app-sandbox = false` these are technically redundant, but their presence creates confusion about the app's actual permission requirements and would unnecessarily widen the attack surface if sandbox were ever re-enabled.

`automation.apple-events` is kept as it's needed for `NSWorkspace.shared.open()` calls.

### 2. Ephemeral browser WebView storage

Uses `WKWebsiteDataStore.nonPersistent()` for the embedded browser so cookies, localStorage, and cache are cleared when the workstream closes. This prevents persistent tracking across sessions without affecting dev server preview functionality.

### Testing

- [ ] App builds without warnings
- [ ] Browser tab loads localhost dev servers correctly
- [ ] Browser tab does not persist cookies between workstream restarts
- [ ] Opening external apps via NSWorkspace still works