### PR TITLE
fix: discover CLI tools from user's login shell PATH

### DIFF
--- a/Sources/Models/CommandLineTools.swift
+++ b/Sources/Models/CommandLineTools.swift
@@ -10,6 +10,9 @@ enum CommandLineTools {
         isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
         resolveFromPath: (String, [String: String]) -> String? = { name, environment in
             pathFromEnvironment(named: name, environment: environment)
+        },
+        resolveFromShellPath: (String) -> String? = { shell in
+            loginShellPath(shell: shell)
         }
     ) -> String? {
         let knownLocations = [
@@ -23,7 +26,67 @@ enum CommandLineTools {
             return location
         }
 
-        return resolveFromPath(name, environment)
+        if let found = resolveFromPath(name, environment) {
+            return found
+        }
+
+        // GUI apps inherit a minimal PATH from launchd. Resolve the user's
+        // login shell PATH to find tools in non-standard locations.
+        guard let shell = environment["SHELL"], !shell.isEmpty else { return nil }
+        guard let shellPath = resolveFromShellPath(shell) else { return nil }
+
+        for directory in shellPath.split(separator: ":") {
+            let candidate = URL(fileURLWithPath: String(directory)).appendingPathComponent(name).path
+            if isExecutable(candidate) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    private static let shellPathCache = ShellPathCache()
+
+    static func loginShellPath(shell: String) -> String? {
+        shellPathCache.resolve(shell: shell)
+    }
+
+    private final class ShellPathCache: Sendable {
+        private let lock = NSLock()
+        private let storage = MutableBox()
+
+        /// Mutable state isolated behind NSLock
+        private final class MutableBox: @unchecked Sendable {
+            var resolved = false
+            var path: String?
+        }
+
+        func resolve(shell: String) -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+
+            if storage.resolved { return storage.path }
+            storage.resolved = true
+
+            let process = Process()
+            let pipe = Pipe()
+            process.executableURL = URL(fileURLWithPath: shell)
+            process.arguments = ["-l", "-c", "echo $PATH"]
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+                process.waitUntilExit()
+                guard process.terminationStatus == 0 else { return nil }
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let result = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                storage.path = result
+                return result
+            } catch {
+                return nil
+            }
+        }
     }
 
     private static func pathFromEnvironment(named name: String, environment: [String: String]) -> String? {

--- a/Tests/CommandLineToolsTests.swift
+++ b/Tests/CommandLineToolsTests.swift
@@ -1,8 +1,8 @@
 // ABOUTME: Tests for resolving absolute paths to app-launched command line tools.
 // ABOUTME: Guards against debug and release builds using different command lookup behavior.
 
-import XCTest
 @testable import FactoryFloor
+import XCTest
 
 final class CommandLineToolsTests: XCTestCase {
     func testPathPrefersKnownExecutableLocations() {
@@ -20,7 +20,7 @@ final class CommandLineToolsTests: XCTestCase {
         let resolved = CommandLineTools.path(
             for: "git",
             environment: ["PATH": "/tmp/custom/bin:/usr/bin"],
-            isExecutable: { path in
+            isExecutable: { _ in
                 false
             },
             resolveFromPath: { name, environment in
@@ -32,5 +32,72 @@ final class CommandLineToolsTests: XCTestCase {
         )
 
         XCTAssertEqual(resolved, "/tmp/custom/bin/git")
+    }
+
+    func testPathFallsBackToShellPath() {
+        // Simulates a GUI app where ProcessInfo PATH is minimal (no custom dirs)
+        // but the user's login shell has the tool in its PATH
+        let resolved = CommandLineTools.path(
+            for: "mytool",
+            environment: ["PATH": "/usr/bin:/bin", "SHELL": "/bin/zsh"],
+            isExecutable: { path in
+                // Not in known locations, not in process PATH
+                // Only found via shell PATH
+                path == "/nix/store/abc123/bin/mytool"
+            },
+            resolveFromPath: { _, _ in nil },
+            resolveFromShellPath: { shell in
+                XCTAssertEqual(shell, "/bin/zsh")
+                return "/nix/store/abc123/bin:/usr/bin"
+            }
+        )
+
+        XCTAssertEqual(resolved, "/nix/store/abc123/bin/mytool")
+    }
+
+    func testShellPathNotUsedWhenKnownLocationMatches() {
+        var shellPathCalled = false
+        let resolved = CommandLineTools.path(
+            for: "git",
+            environment: ["SHELL": "/bin/zsh"],
+            isExecutable: { $0 == "/opt/homebrew/bin/git" },
+            resolveFromPath: { _, _ in
+                XCTFail("Should not reach process PATH")
+                return nil
+            },
+            resolveFromShellPath: { _ in
+                shellPathCalled = true
+                return "/some/path"
+            }
+        )
+
+        XCTAssertEqual(resolved, "/opt/homebrew/bin/git")
+        XCTAssertFalse(shellPathCalled, "Shell PATH should not be queried when known location matches")
+    }
+
+    func testShellPathSkippedWhenProcessPathMatches() {
+        var shellPathCalled = false
+        let resolved = CommandLineTools.path(
+            for: "mytool",
+            environment: ["PATH": "/custom/bin", "SHELL": "/bin/zsh"],
+            isExecutable: { $0 == "/custom/bin/mytool" },
+            resolveFromPath: { name, env in
+                let rawPath = env["PATH"] ?? ""
+                for dir in rawPath.split(separator: ":") {
+                    let candidate = "\(dir)/\(name)"
+                    if FileManager.default.isExecutableFile(atPath: candidate) || candidate == "/custom/bin/mytool" {
+                        return candidate
+                    }
+                }
+                return nil
+            },
+            resolveFromShellPath: { _ in
+                shellPathCalled = true
+                return "/some/path"
+            }
+        )
+
+        XCTAssertEqual(resolved, "/custom/bin/mytool")
+        XCTAssertFalse(shellPathCalled, "Shell PATH should not be queried when process PATH matches")
     }
 }


### PR DESCRIPTION
## Summary
- macOS GUI apps inherit a minimal PATH from launchd (`/usr/bin:/bin:/usr/sbin:/sbin`), so tools installed via nix, asdf, mise, or other non-standard package managers are invisible to tool detection
- Added a third fallback tier to `CommandLineTools.path(for:)` that spawns the user's login shell (`$SHELL -l -c 'echo $PATH'`) to resolve their full PATH
- Shell PATH result is cached (once per app launch) behind an `NSLock` for Swift 6 concurrency safety

## Test plan
- [x] Added `testPathFallsBackToShellPath` — verifies tool found via shell PATH when known locations and process PATH miss
- [x] Added `testShellPathNotUsedWhenKnownLocationMatches` — verifies shell PATH is never queried when a known location hits
- [x] Added `testShellPathSkippedWhenProcessPathMatches` — verifies shell PATH is never queried when process PATH hits
- [x] All 90 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)