### PR TITLE
fix: suppress incomplete umbrella header warnings from GhosttyKit

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -13,6 +13,9 @@ settings:
     SWIFT_OBJC_BRIDGING_HEADER: Resources/FactoryFloor-Bridging-Header.h
     HEADER_SEARCH_PATHS:
       - $(PROJECT_DIR)/ghostty/include
+    OTHER_SWIFT_FLAGS:
+      - "-Xcc"
+      - "-Wno-incomplete-umbrella"
     MACOSX_DEPLOYMENT_TARGET: "14.0"
     CODE_SIGN_IDENTITY: "-"
     CODE_SIGNING_REQUIRED: "NO"


### PR DESCRIPTION
## Summary
- Suppress `-Wincomplete-umbrella` warnings caused by ghostty submodule's module map declaring `ghostty.h` as an umbrella header without including the newer `vt/*.h` headers
- Adds `-Xcc -Wno-incomplete-umbrella` to `OTHER_SWIFT_FLAGS` in `project.yml`

## Test plan
- [x] `./scripts/dev.sh build` succeeds with zero umbrella header warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)