### PR TITLE
feat: show changelog in Sparkle update window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,11 +232,13 @@ jobs:
           fi
 
           DMG_URL="https://github.com/alltuner/factoryfloor/releases/download/v${VERSION}/${DMG_NAME}"
+          RELEASE_NOTES_URL="https://github.com/alltuner/factoryfloor/releases/tag/v${VERSION}"
           python3 scripts/generate_appcast.py \
             --version "$VERSION" \
             --signature "$SIGNATURE" \
             --dmg-path "build/release/$DMG_NAME" \
             --dmg-url "$DMG_URL" \
+            --release-notes-url "$RELEASE_NOTES_URL" \
             --output appcast.xml
 
       - name: Upload to release

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -13,6 +13,7 @@ def build_appcast(
     dmg_length: int,
     dmg_url: str,
     min_os: str = "14.0",
+    release_notes_url: str | None = None,
 ) -> str:
     rss = ET.Element("rss")
     rss.set("version", "2.0")
@@ -32,6 +33,8 @@ def build_appcast(
     )
     ET.SubElement(item, "pubDate").text = pub_date
     ET.SubElement(item, "sparkle:minimumSystemVersion").text = min_os
+    if release_notes_url:
+        ET.SubElement(item, "sparkle:releaseNotesLink").text = release_notes_url
 
     enclosure = ET.SubElement(item, "enclosure")
     enclosure.set("url", dmg_url)
@@ -52,6 +55,7 @@ def main() -> None:
     parser.add_argument("--signature", required=True, help="Ed25519 signature from sign_update")
     parser.add_argument("--dmg-path", required=True, help="Path to the DMG file")
     parser.add_argument("--dmg-url", required=True, help="Download URL for the DMG")
+    parser.add_argument("--release-notes-url", default=None, help="URL for release notes")
     parser.add_argument("--output", default="appcast.xml", help="Output path")
     args = parser.parse_args()
 
@@ -61,6 +65,7 @@ def main() -> None:
         signature=args.signature,
         dmg_length=dmg_length,
         dmg_url=args.dmg_url,
+        release_notes_url=args.release_notes_url,
     )
 
     with open(args.output, "w") as f:


### PR DESCRIPTION
## Summary
- Add `sparkle:releaseNotesLink` to appcast XML, pointing to the GitHub release page
- Sparkle renders this in its update dialog so users can see what changed before updating
- No changes needed to the Swift side; Sparkle picks this up automatically from the feed

## Test plan
- [ ] Verify `generate_appcast.py --release-notes-url` produces valid XML with the link
- [ ] Confirm Sparkle update dialog shows release notes on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)