### PR TITLE
fix: create logs directory before revealing in Finder

### DIFF
--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -145,6 +145,7 @@ struct SettingsView: View {
                     if detailedLogging {
                         Spacer()
                         Button("Show Logs") {
+                            try? ScriptLogger.ensureLogDirectory()
                             NSWorkspace.shared.open(ScriptLogger.logDirectory)
                         }
                         .font(.caption)


### PR DESCRIPTION
## Summary
- `NSWorkspace.shared.open()` silently fails when the target directory doesn't exist
- The logs directory (`~/Library/Caches/factoryfloor/logs/`) is only created when a script runs with logging enabled, so clicking "Show Logs" before that does nothing
- Calls `ScriptLogger.ensureLogDirectory()` before opening

## Test plan
- [ ] Enable detailed logging in Settings, click "Show Logs" without having run any scripts — Finder should open the (now-created) logs directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)