### PR TITLE
fix: close button on workspace tabs not working

### DIFF
--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -722,16 +722,14 @@ private struct WorkspaceTabButton: View {
                         .foregroundStyle(.tertiary)
                 }
                 if let onClose, isHovering || isActive {
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 8, weight: .bold))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 14, height: 14)
-                            .background(Color.primary.opacity(0.1))
-                            .clipShape(Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Close tab")
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 14, height: 14)
+                        .background(Color.primary.opacity(0.1))
+                        .clipShape(Circle())
+                        .onTapGesture(perform: onClose)
+                        .accessibilityLabel("Close tab")
                 }
             }
             .padding(.horizontal, 10)


### PR DESCRIPTION
## Summary
- The close button (xmark) on terminal and browser tabs was non-functional because it was a nested `Button` inside the tab selection `Button`
- SwiftUI propagated the tap to the outer button, triggering tab selection instead of closing
- Replaced the inner `Button` with `Image` + `.onTapGesture` to consume the gesture without propagation

## Test plan
- [ ] Open a project, create a terminal tab (Cmd+T), click the xmark to close it
- [ ] Create a browser tab (Cmd+B), click the xmark to close it
- [ ] Verify Cmd+W still closes tabs
- [ ] Verify tab selection still works by clicking the tab body (not the xmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)