### PR TITLE
fix: inject login shell PATH into terminal environment

### DIFF
--- a/Sources/Models/WorkstreamEnvironment.swift
+++ b/Sources/Models/WorkstreamEnvironment.swift
@@ -23,6 +23,10 @@ enum WorkstreamEnvironment {
         if agentTeams {
             vars["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
         }
+        let shell = CommandBuilder.userShell
+        if let path = CommandLineTools.loginShellPath(shell: shell) {
+            vars["PATH"] = path
+        }
         return vars
     }
 }


### PR DESCRIPTION
## Summary
- Wrapper scripts around `claude` need the full user PATH to resolve dependencies (e.g., `node`)
- macOS GUI apps inherit minimal PATH from launchd, so wrappers that work in a regular terminal fail when launched from Factory Floor
- Injects the cached login shell PATH into every terminal's process environment via `WorkstreamEnvironment`

## Test plan
- [ ] Install claude via a wrapper script (e.g., a shell script that calls the real binary)
- [ ] Verify the agent tab launches successfully with the wrapper
- [ ] Verify tmux mode also works with the wrapper
- [ ] Verify plain terminal tabs still get correct PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)