### PR TITLE
feat: show changelog in Sparkle update window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           version: 0.15.2
 
+      - uses: astral-sh/setup-uv@v5
+
       - name: Cache SPM packages
         uses: actions/cache@v5
         with:
@@ -217,7 +219,9 @@ jobs:
       - name: Generate appcast
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.release-please.outputs.version }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           echo "$SPARKLE_PRIVATE_KEY" > /tmp/sparkle_key
           SIGN_OUTPUT=$(sign_update -f /tmp/sparkle_key "build/release/$DMG_NAME")
@@ -231,6 +235,9 @@ jobs:
             exit 1
           fi
 
+          RELEASE_NOTES=$(gh release view "$TAG_NAME" --json body -q .body)
+          RELEASE_NOTES=$(echo "$RELEASE_NOTES" | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
+
           DMG_URL="https://github.com/alltuner/factoryfloor/releases/download/v${VERSION}/${DMG_NAME}"
           RELEASE_NOTES_URL="https://github.com/alltuner/factoryfloor/releases/tag/v${VERSION}"
           python3 scripts/generate_appcast.py \
@@ -239,6 +246,7 @@ jobs:
             --dmg-path "build/release/$DMG_NAME" \
             --dmg-url "$DMG_URL" \
             --release-notes-url "$RELEASE_NOTES_URL" \
+            --release-notes "$RELEASE_NOTES" \
             --output appcast.xml
 
       - name: Upload to release

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -14,6 +14,7 @@ def build_appcast(
     dmg_url: str,
     min_os: str = "14.0",
     release_notes_url: str | None = None,
+    release_notes: str | None = None,
 ) -> str:
     rss = ET.Element("rss")
     rss.set("version", "2.0")
@@ -36,6 +37,9 @@ def build_appcast(
     if release_notes_url:
         ET.SubElement(item, "sparkle:releaseNotesLink").text = release_notes_url
 
+    if release_notes:
+        ET.SubElement(item, "description").text = release_notes
+
     enclosure = ET.SubElement(item, "enclosure")
     enclosure.set("url", dmg_url)
     enclosure.set("sparkle:version", version)
@@ -56,6 +60,7 @@ def main() -> None:
     parser.add_argument("--dmg-path", required=True, help="Path to the DMG file")
     parser.add_argument("--dmg-url", required=True, help="Download URL for the DMG")
     parser.add_argument("--release-notes-url", default=None, help="URL for release notes")
+    parser.add_argument("--release-notes", default=None, help="Release notes text to embed")
     parser.add_argument("--output", default="appcast.xml", help="Output path")
     args = parser.parse_args()
 
@@ -66,6 +71,7 @@ def main() -> None:
         dmg_length=dmg_length,
         dmg_url=args.dmg_url,
         release_notes_url=args.release_notes_url,
+        release_notes=args.release_notes,
     )
 
     with open(args.output, "w") as f:

--- a/scripts/test_generate_appcast.py
+++ b/scripts/test_generate_appcast.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for generate_appcast.py."""
+
+import xml.etree.ElementTree as ET
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from generate_appcast import build_appcast
+
+
+def parse(xml_str: str) -> ET.Element:
+    return ET.fromstring(xml_str)
+
+
+def test_no_release_notes_omits_description() -> None:
+    """When no release notes are provided, description element should be absent."""
+    xml = build_appcast(
+        version="1.0.0",
+        signature="abc123",
+        dmg_length=999,
+        dmg_url="https://example.com/app.dmg",
+    )
+    root = parse(xml)
+    item = root.find(".//item")
+    assert item is not None, "Expected <item> element"
+    desc = item.find("description")
+    assert desc is None, "Expected no <description> when release_notes not provided"
+    print("PASS: no_release_notes_omits_description")
+
+
+def test_release_notes_embedded_as_description() -> None:
+    """When release notes are provided, they should appear in a description element."""
+    notes = "## What's New\n\n* Added feature X\n* Fixed bug Y"
+    xml = build_appcast(
+        version="1.2.0",
+        signature="sig456",
+        dmg_length=5000,
+        dmg_url="https://example.com/app.dmg",
+        release_notes=notes,
+    )
+    root = parse(xml)
+    item = root.find(".//item")
+    assert item is not None, "Expected <item> element"
+    desc = item.find("description")
+    assert desc is not None, "Expected <description> element when release_notes provided"
+    assert notes in desc.text, f"Expected release notes in description, got: {desc.text}"
+    print("PASS: release_notes_embedded_as_description")
+
+
+def test_release_notes_with_html_entities() -> None:
+    """Release notes with special XML characters should be handled safely."""
+    notes = "Fix for <div> & \"quotes\" in output"
+    xml = build_appcast(
+        version="1.3.0",
+        signature="sig789",
+        dmg_length=3000,
+        dmg_url="https://example.com/app.dmg",
+        release_notes=notes,
+    )
+    # Should parse without error (XML-safe)
+    root = parse(xml)
+    desc = root.find(".//item/description")
+    assert desc is not None
+    assert notes in desc.text
+    print("PASS: release_notes_with_html_entities")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, func in list(globals().items()):
+        if name.startswith("test_") and callable(func):
+            try:
+                func()
+            except (AssertionError, TypeError) as e:
+                print(f"FAIL: {name}: {e}")
+                failures += 1
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary
- Embed release-please changelog as HTML in the Sparkle appcast `<description>` element
- Adds `--release-notes` arg to `generate_appcast.py`, converts markdown to HTML via `uvx --with markdown` in CI
- Users see formatted release notes directly in the Sparkle update dialog instead of a blank window

## Test plan
- [x] Unit tests pass for appcast generation (with/without release notes, XML-safe special chars)
- [ ] Verify next release shows changelog in Sparkle update dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)