### PR TITLE
fix: disable update checker in debug builds

### DIFF
--- a/Sources/Models/UpdateChecker.swift
+++ b/Sources/Models/UpdateChecker.swift
@@ -17,19 +17,23 @@ class UpdateChecker: ObservableObject {
     }
 
     func check() {
-        Task.detached { [currentVersion, logger] in
-            do {
-                let (data, _) = try await URLSession.shared.data(from: Self.appcastURL)
-                guard let version = Self.parseVersion(from: data) else { return }
-                if Self.isNewer(version, than: currentVersion) {
-                    await MainActor.run { [weak self] in
-                        self?.availableVersion = version
+        #if DEBUG
+            return
+        #else
+            Task.detached { [currentVersion, logger] in
+                do {
+                    let (data, _) = try await URLSession.shared.data(from: Self.appcastURL)
+                    guard let version = Self.parseVersion(from: data) else { return }
+                    if Self.isNewer(version, than: currentVersion) {
+                        await MainActor.run { [weak self] in
+                            self?.availableVersion = version
+                        }
                     }
+                } catch {
+                    logger.debug("Update check failed: \(error.localizedDescription)")
                 }
-            } catch {
-                logger.debug("Update check failed: \(error.localizedDescription)")
             }
-        }
+        #endif
     }
 
     /// Extracts the sparkle:shortVersionString from the first enclosure in an appcast feed.


### PR DESCRIPTION
## Summary
- Wraps `UpdateChecker.check()` body with `#if !DEBUG` so the appcast fetch never runs in debug builds
- Since `availableVersion` stays `nil`, the sidebar update banner never appears

## Test plan
- [ ] Debug build: verify no update banner appears in the sidebar
- [ ] Release build: verify update banner still works when a newer version exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)