### PR TITLE
fix: resolve LSP false positives for conditionally compiled AppConstants

### DIFF
--- a/Sources/Models/AppConstants.swift
+++ b/Sources/Models/AppConstants.swift
@@ -24,15 +24,29 @@ func resolvedConfigDirectory(
 }
 
 enum AppConstants {
-    #if DEBUG
-        static let appID = "factoryfloor-debug"
-        static let appName = "Factory Floor Debug"
-        static let urlScheme = "factoryfloor-debug"
-    #else
-        static let appID = "factoryfloor"
-        static let appName = "Factory Floor"
-        static let urlScheme = "factoryfloor"
-    #endif
+    static let appID: String = {
+        #if DEBUG
+            "factoryfloor-debug"
+        #else
+            "factoryfloor"
+        #endif
+    }()
+
+    static let appName: String = {
+        #if DEBUG
+            "Factory Floor Debug"
+        #else
+            "Factory Floor"
+        #endif
+    }()
+
+    static let urlScheme: String = {
+        #if DEBUG
+            "factoryfloor-debug"
+        #else
+            "factoryfloor"
+        #endif
+    }()
 
     static var version: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"


### PR DESCRIPTION
## Summary
- Restructured `AppConstants` so `#if DEBUG` is inside closure initializers rather than wrapping entire property declarations
- SourceKit now always sees all properties regardless of active build configuration, eliminating false "Cannot find in scope" diagnostics

Closes #211

## Test plan
- [x] Debug build succeeds
- [x] Tests pass
- [ ] Verify LSP no longer reports false positives on `AppConstants` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)