### PR TITLE
fix: run worktree build in background to speed up creation

### DIFF
--- a/.hooks/worktree-create.sh
+++ b/.hooks/worktree-create.sh
@@ -16,5 +16,6 @@ fi
 
 # Build so SourceKit can resolve symbols across files in the worktree.
 # dev.sh runs xcodegen + xcodebuild with the shared SPM cache.
+# Runs in background to avoid blocking worktree creation.
 cd "$WORKTREE_DIR"
-./scripts/dev.sh build
+nohup ./scripts/dev.sh build >/dev/null 2>&1 &


### PR DESCRIPTION
## Summary
- The project hook (`.hooks/worktree-create.sh`) runs `./scripts/dev.sh build` synchronously during worktree creation, blocking for the full xcodegen + xcodebuild duration
- Wraps the build in `nohup ... &` so worktree creation returns immediately while SourceKit catches up in the background

## Test plan
- [ ] Create a new worktree and verify it returns quickly
- [ ] Verify the build still completes in the background (check with `ps aux | grep dev.sh` or wait for SourceKit to resolve symbols)

🤖 Generated with [Claude Code](https://claude.com/claude-code)