### PR TITLE
fix(website): prevent horizontal scroll on mobile Safari

### DIFF
--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" class="scroll-smooth dark">
+<html lang="{{ .Site.Language.Lang }}" class="scroll-smooth dark overflow-x-hidden">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- Add `overflow-x-hidden` to `<html>` element in `baseof.html`
- Mobile Safari ignores `overflow-x: hidden` on `<body>` alone, allowing horizontal panning when absolutely-positioned elements (like the hero glow) extend beyond the viewport

## Test plan
- [ ] Open factory-floor.com on iOS Safari and verify no horizontal scroll/pan

🤖 Generated with [Claude Code](https://claude.com/claude-code)