### PR TITLE
fix: read Sparkle changelog from CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,17 +235,23 @@ jobs:
             exit 1
           fi
 
-          RELEASE_NOTES=$(gh release view "$TAG_NAME" --json body -q .body)
-          RELEASE_NOTES=$(echo "$RELEASE_NOTES" | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
+          # Extract current version's changelog section and convert to HTML
+          RELEASE_NOTES=$(python3 -c "
+          import re, sys
+          text = open('CHANGELOG.md').read()
+          # Match from '## [version]' to the next '## [' or end of file
+          pattern = r'## \[${VERSION}\].*?\n(.*?)(?=\n## \[|\Z)'
+          m = re.search(pattern, text, re.DOTALL)
+          if m:
+              print(m.group(1).strip())
+          " | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
 
           DMG_URL="https://github.com/alltuner/factoryfloor/releases/download/v${VERSION}/${DMG_NAME}"
-          RELEASE_NOTES_URL="https://github.com/alltuner/factoryfloor/releases/tag/v${VERSION}"
           python3 scripts/generate_appcast.py \
             --version "$VERSION" \
             --signature "$SIGNATURE" \
             --dmg-path "build/release/$DMG_NAME" \
             --dmg-url "$DMG_URL" \
-            --release-notes-url "$RELEASE_NOTES_URL" \
             --release-notes "$RELEASE_NOTES" \
             --output appcast.xml
 

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -13,7 +13,6 @@ def build_appcast(
     dmg_length: int,
     dmg_url: str,
     min_os: str = "14.0",
-    release_notes_url: str | None = None,
     release_notes: str | None = None,
 ) -> str:
     rss = ET.Element("rss")
@@ -34,8 +33,6 @@ def build_appcast(
     )
     ET.SubElement(item, "pubDate").text = pub_date
     ET.SubElement(item, "sparkle:minimumSystemVersion").text = min_os
-    if release_notes_url:
-        ET.SubElement(item, "sparkle:releaseNotesLink").text = release_notes_url
 
     if release_notes:
         ET.SubElement(item, "description").text = release_notes
@@ -59,8 +56,7 @@ def main() -> None:
     parser.add_argument("--signature", required=True, help="Ed25519 signature from sign_update")
     parser.add_argument("--dmg-path", required=True, help="Path to the DMG file")
     parser.add_argument("--dmg-url", required=True, help="Download URL for the DMG")
-    parser.add_argument("--release-notes-url", default=None, help="URL for release notes")
-    parser.add_argument("--release-notes", default=None, help="Release notes text to embed")
+    parser.add_argument("--release-notes", default=None, help="Release notes HTML to embed")
     parser.add_argument("--output", default="appcast.xml", help="Output path")
     args = parser.parse_args()
 
@@ -70,7 +66,6 @@ def main() -> None:
         signature=args.signature,
         dmg_length=dmg_length,
         dmg_url=args.dmg_url,
-        release_notes_url=args.release_notes_url,
         release_notes=args.release_notes,
     )
 


### PR DESCRIPTION
## Summary
- Remove `sparkle:releaseNotesLink` from appcast so Sparkle displays inline HTML instead of loading the GitHub release page
- Source release notes from `CHANGELOG.md` directly instead of fetching via `gh release view`
- Remove `--release-notes-url` parameter from `generate_appcast.py`

## Test plan
- [x] `test_generate_appcast.py` passes
- [ ] Verify next release appcast contains `<description>` HTML without `<sparkle:releaseNotesLink>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)