### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ ghostty/.zig-cache/
 # Node dependencies (installed via bun in CI)
 node_modules/
 
+# Python
+__pycache__/
+
 # macOS
 .DS_Store
 *.swp


### PR DESCRIPTION
## Summary
- Adds `__pycache__/` to `.gitignore` so Python bytecode caches from running tests locally don't show as untracked files

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)