### PR TITLE
feat: add launch at login toggle

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -94,6 +94,8 @@
 "Quit" = "Sortir";
 "Confirm before quitting" = "Confirma abans de sortir";
 "Show a confirmation dialog when quitting with active workstreams." = "Mostra un diàleg de confirmació en sortir amb fluxos de treball actius.";
+"Launch at login" = "Obre en iniciar sessió";
+"Automatically open Factory Floor when you log in." = "Obre Factory Floor automàticament en iniciar sessió.";
 "Detailed logging" = "Registre detallat";
 "Log setup, run, and teardown script output to files for debugging." = "Registra la sortida dels scripts de configuració, execució i desmuntatge en fitxers per a depuració.";
 

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -94,6 +94,8 @@
 "Quit" = "Quit";
 "Confirm before quitting" = "Confirm before quitting";
 "Show a confirmation dialog when quitting with active workstreams." = "Show a confirmation dialog when quitting with active workstreams.";
+"Launch at login" = "Launch at login";
+"Automatically open Factory Floor when you log in." = "Automatically open Factory Floor when you log in.";
 "Detailed logging" = "Detailed logging";
 "Log setup, run, and teardown script output to files for debugging." = "Log setup, run, and teardown script output to files for debugging.";
 

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -94,6 +94,8 @@
 "Quit" = "Salir";
 "Confirm before quitting" = "Confirmar antes de salir";
 "Show a confirmation dialog when quitting with active workstreams." = "Muestra un diálogo de confirmación al salir con flujos de trabajo activos.";
+"Launch at login" = "Abrir al iniciar sesión";
+"Automatically open Factory Floor when you log in." = "Abre Factory Floor automáticamente al iniciar sesión.";
 "Detailed logging" = "Registro detallado";
 "Log setup, run, and teardown script output to files for debugging." = "Registra la salida de los scripts de configuración, ejecución y desmontaje en archivos para depuración.";
 

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -94,6 +94,8 @@
 "Quit" = "Avsluta";
 "Confirm before quitting" = "Bekräfta innan avslut";
 "Show a confirmation dialog when quitting with active workstreams." = "Visa en bekräftelsedialog vid avslut med aktiva arbetsflöden.";
+"Launch at login" = "Öppna vid inloggning";
+"Automatically open Factory Floor when you log in." = "Öppna Factory Floor automatiskt vid inloggning.";
 "Detailed logging" = "Detaljerad loggning";
 "Log setup, run, and teardown script output to files for debugging." = "Logga utdata från konfigurations-, körnings- och nedmonteringsskript till filer för felsökning.";
 

--- a/Sources/Models/LaunchAtLogin.swift
+++ b/Sources/Models/LaunchAtLogin.swift
@@ -1,0 +1,27 @@
+// ABOUTME: Manages the app's launch-at-login registration via SMAppService.
+// ABOUTME: Provides a simple enable/disable interface backed by the system login item service.
+
+import OSLog
+import ServiceManagement
+
+enum LaunchAtLogin {
+    private static let logger = Logger(subsystem: AppConstants.appID, category: "LaunchAtLogin")
+
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    static func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+                logger.info("Registered launch at login")
+            } else {
+                try SMAppService.mainApp.unregister()
+                logger.info("Unregistered launch at login")
+            }
+        } catch {
+            logger.error("Failed to \(enabled ? "register" : "unregister") launch at login: \(error)")
+        }
+    }
+}

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -21,6 +21,8 @@ struct SettingsView: View {
     @AppStorage("factoryfloor.bleedingEdge") private var bleedingEdge: Bool = false
     @AppStorage("factoryfloor.baseDirectory") private var baseDirectory: String = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first ?? ""
 
+    @State private var launchAtLogin = LaunchAtLogin.isEnabled
+
     @EnvironmentObject private var appEnv: AppEnvironment
     @State private var showingClearConfirm = false
     #if DEBUG
@@ -134,6 +136,14 @@ struct SettingsView: View {
 
                 Toggle("Confirm before quitting", isOn: $confirmQuit)
                 Text("Show a confirmation dialog when quitting with active workstreams.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Launch at login", isOn: $launchAtLogin)
+                    .onChange(of: launchAtLogin) { _, newValue in
+                        LaunchAtLogin.setEnabled(newValue)
+                    }
+                Text("Automatically open Factory Floor when you log in.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
## Summary
- Adds a "Launch at login" toggle to Settings (Projects section), defaulting to off
- Uses `SMAppService.mainApp` directly (available since macOS 13, we target 14) instead of a third-party package
- Localized in all 4 locales (en, ca, es, sv)

Closes #224

## Test plan
- [x] Build succeeds
- [x] All 90 existing tests pass
- [ ] Toggle appears in Settings > Projects, after "Confirm before quitting"
- [ ] Toggling on registers the app as a login item (visible in System Settings > General > Login Items)
- [ ] Toggling off removes it
- [ ] Default state is off on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)