### PR TITLE
fix: trigger Sparkle update from sidebar instead of opening website

### DIFF
--- a/Sources/Models/Updater.swift
+++ b/Sources/Models/Updater.swift
@@ -38,6 +38,12 @@ final class Updater: ObservableObject {
         updater?.canCheckForUpdates ?? false
     }
 
+    /// Whether Sparkle was successfully initialized (DMG installs).
+    /// Unlike `canCheckForUpdates`, this doesn't depend on transient Sparkle state.
+    var isConfigured: Bool {
+        updater != nil
+    }
+
     func checkForUpdates() {
         updater?.checkForUpdates()
     }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -755,7 +755,7 @@ private struct UpdateBanner: View {
 
     var body: some View {
         Button {
-            if updater.canCheckForUpdates {
+            if updater.isConfigured {
                 updater.checkForUpdates()
             } else {
                 NSWorkspace.shared.open(getURL)


### PR DESCRIPTION
## Summary
- Add `isConfigured` property to `Updater` that checks if Sparkle was successfully initialized (stable, unlike the transient `canCheckForUpdates`)
- Sidebar update banner now triggers Sparkle for DMG users, falls back to website for Homebrew users

## Test plan
- [ ] DMG install: click "update available" banner triggers Sparkle update dialog
- [ ] Homebrew install: click "update available" banner opens website

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)