### PR TITLE
feat(website): add download button to /get/ page

### DIFF
--- a/website/layouts/_default/get.html
+++ b/website/layouts/_default/get.html
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <a href="{{ .Site.Params.downloadURL }}" class="inline-flex items-center gap-2 text-wine-light no-underline hover:text-fg transition-colors font-mono text-sm">
+    <a href="{{ .Site.Params.downloadURL }}" class="inline-flex items-center gap-2 bg-wine text-[#F7F4F3] px-6 py-3 rounded-lg text-sm no-underline transition-all hover:bg-wine-light hover:-translate-y-px font-mono">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
       {{ T "get_download" }}
     </a>


### PR DESCRIPTION
## Summary
- Restyle the download link on `/get/` as a prominent button with `bg-wine` background, matching the nav's download button style
- Reuses existing `get_download` i18n key and `downloadURL` site param

## Test plan
- [ ] Visit `/get/` page and verify prominent download button is visible
- [ ] Verify button links to the correct DMG download URL
- [ ] Verify styling matches the site's visual language

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)