### PR TITLE
fix: resolve compiler warnings in Launcher, BrowserView, and Updater

### DIFF
--- a/Sources/Launcher/main.swift
+++ b/Sources/Launcher/main.swift
@@ -33,7 +33,7 @@ private func launchCommand(configuration: Configuration) throws {
     guard _NSGetExecutablePath(&pathBuf, &pathLen) == 0 else {
         throw LauncherError(exitCode: 1, message: "cannot determine ff-run path")
     }
-    let selfPath = String(cString: pathBuf)
+    let selfPath = String(decoding: pathBuf.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
 
     let monitorArgs = [
         selfPath,

--- a/Sources/Models/Updater.swift
+++ b/Sources/Models/Updater.swift
@@ -20,7 +20,7 @@ final class Updater: ObservableObject {
         #if !DEBUG
             let userDriver = SilentErrorUserDriver(hostBundle: .main, delegate: nil)
             do {
-                let spuUpdater = try SPUUpdater(
+                let spuUpdater = SPUUpdater(
                     hostBundle: .main,
                     applicationBundle: .main,
                     userDriver: userDriver,

--- a/Sources/Views/BrowserView.swift
+++ b/Sources/Views/BrowserView.swift
@@ -245,6 +245,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
         }
 
+        @MainActor
         func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String,
                      initiatedByFrame _: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (Bool) -> Void)
         {


### PR DESCRIPTION
## Summary
- Replace deprecated `String(cString:)` with `String(decoding:as: UTF8.self)` in Launcher
- Add `@MainActor` to WKUIDelegate method in BrowserView to match protocol
- Remove unnecessary `try` from `SPUUpdater()` init in Updater

## Test plan
- [ ] Build produces zero warnings from our source files
- [ ] All tests pass

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)