### PR TITLE
fix: consolidate settings from 7 sections to 4

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -104,40 +104,31 @@
 "Installed" = "Instal·lat";
 "Install..." = "Instal·la...";
 
-/* Settings - Projects */
-"Projects" = "Projectes";
+/* Settings - General */
+"General" = "General";
 "Base directory" = "Directori base";
 "Change..." = "Canvia...";
 "Choose base directory for projects" = "Tria el directori base per als projectes";
 "Default location when adding new projects." = "Ubicació per defecte en afegir nous projectes.";
 "Branch prefix" = "Prefix de branca";
-
-/* Settings - Terminal & Browser */
-"Terminal & Browser" = "Terminal i navegador";
-"External Browser" = "Navegador extern";
+"Theme" = "Tema";
+"System" = "Sistema";
+"Light" = "Clar";
+"Dark" = "Fosc";
 
 /* Settings - Coding Agent */
 "Agent Teams" = "Equips d'agents";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Activa la coordinació experimental multi-agent. Els agents poden crear companys d'equip, delegar tasques i col·laborar entre fluxos de treball.";
 "Auto-rename branch" = "Canvia el nom de la branca automàticament";
 "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "L'agent canviarà el nom de la branca de l'arbre de treball per coincidir amb la tasca a la primera sol·licitud (p. ex., fix-login-timeout).";
+"External Browser" = "Navegador extern";
 
-/* Settings - Appearance */
-"Appearance" = "Aparença";
-"Theme" = "Tema";
-"System" = "Sistema";
-"Light" = "Clar";
-"Dark" = "Fosc";
-
-/* Settings - Privacy & Logging */
-"Privacy & Logging" = "Privacitat i registres";
+/* Settings - Advanced */
+"Advanced" = "Avançat";
 "Usage analytics" = "Analítiques d'ús";
 "Send anonymous usage data to help improve Factory Floor. We collect: app version, build type, macOS version, locale, and screen resolution. No project names, file contents, or personal data." = "Envia dades d'ús anònimes per ajudar a millorar Factory Floor. Recollim: versió de l'aplicació, tipus de compilació, versió de macOS, idioma i resolució de pantalla. Cap nom de projecte, contingut de fitxers ni dades personals.";
 "Crash reports" = "Informes d'errors";
 "Send crash reports and performance data. Requires restart to take effect." = "Envia informes d'errors i dades de rendiment. Requereix reiniciar l'aplicació.";
-
-/* Settings - Danger Zone */
-"Danger Zone" = "Zona de perill";
 "Bleeding edge" = "Últimes novetats";
 "Receive pre-release builds with the latest features. These may be less stable." = "Rep versions preliminars amb les últimes funcions. Poden ser menys estables.";
 "Clear project list" = "Esborra la llista de projectes";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -104,40 +104,31 @@
 "Installed" = "Installed";
 "Install..." = "Install...";
 
-/* Settings - Projects */
-"Projects" = "Projects";
+/* Settings - General */
+"General" = "General";
 "Base directory" = "Base directory";
 "Change..." = "Change...";
 "Choose base directory for projects" = "Choose base directory for projects";
 "Default location when adding new projects." = "Default location when adding new projects.";
 "Branch prefix" = "Branch prefix";
-
-/* Settings - Terminal & Browser */
-"Terminal & Browser" = "Terminal & Browser";
-"External Browser" = "External Browser";
+"Theme" = "Theme";
+"System" = "System";
+"Light" = "Light";
+"Dark" = "Dark";
 
 /* Settings - Coding Agent */
 "Agent Teams" = "Agent Teams";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams.";
 "Auto-rename branch" = "Auto-rename branch";
 "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout).";
+"External Browser" = "External Browser";
 
-/* Settings - Appearance */
-"Appearance" = "Appearance";
-"Theme" = "Theme";
-"System" = "System";
-"Light" = "Light";
-"Dark" = "Dark";
-
-/* Settings - Privacy & Logging */
-"Privacy & Logging" = "Privacy & Logging";
+/* Settings - Advanced */
+"Advanced" = "Advanced";
 "Usage analytics" = "Usage analytics";
 "Send anonymous usage data to help improve Factory Floor. We collect: app version, build type, macOS version, locale, and screen resolution. No project names, file contents, or personal data." = "Send anonymous usage data to help improve Factory Floor. We collect: app version, build type, macOS version, locale, and screen resolution. No project names, file contents, or personal data.";
 "Crash reports" = "Crash reports";
 "Send crash reports and performance data. Requires restart to take effect." = "Send crash reports and performance data. Requires restart to take effect.";
-
-/* Settings - Danger Zone */
-"Danger Zone" = "Danger Zone";
 "Bleeding edge" = "Bleeding edge";
 "Receive pre-release builds with the latest features. These may be less stable." = "Receive pre-release builds with the latest features. These may be less stable.";
 "Clear project list" = "Clear project list";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -104,40 +104,31 @@
 "Installed" = "Instalado";
 "Install..." = "Instalar...";
 
-/* Settings - Projects */
-"Projects" = "Proyectos";
+/* Settings - General */
+"General" = "General";
 "Base directory" = "Directorio base";
 "Change..." = "Cambiar...";
 "Choose base directory for projects" = "Elige el directorio base para los proyectos";
 "Default location when adding new projects." = "Ubicación predeterminada al añadir nuevos proyectos.";
 "Branch prefix" = "Prefijo de rama";
-
-/* Settings - Terminal & Browser */
-"Terminal & Browser" = "Terminal y navegador";
-"External Browser" = "Navegador externo";
+"Theme" = "Tema";
+"System" = "Sistema";
+"Light" = "Claro";
+"Dark" = "Oscuro";
 
 /* Settings - Coding Agent */
 "Agent Teams" = "Equipos de agentes";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Activa la coordinación experimental multi-agente. Los agentes pueden crear compañeros, delegar tareas y colaborar entre flujos de trabajo.";
 "Auto-rename branch" = "Renombrar rama automáticamente";
 "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "El agente renombrará la rama del árbol de trabajo para coincidir con la tarea en la primera solicitud (p. ej., fix-login-timeout).";
+"External Browser" = "Navegador externo";
 
-/* Settings - Appearance */
-"Appearance" = "Apariencia";
-"Theme" = "Tema";
-"System" = "Sistema";
-"Light" = "Claro";
-"Dark" = "Oscuro";
-
-/* Settings - Privacy & Logging */
-"Privacy & Logging" = "Privacidad y registros";
+/* Settings - Advanced */
+"Advanced" = "Avanzado";
 "Usage analytics" = "Analíticas de uso";
 "Send anonymous usage data to help improve Factory Floor. We collect: app version, build type, macOS version, locale, and screen resolution. No project names, file contents, or personal data." = "Envía datos de uso anónimos para ayudar a mejorar Factory Floor. Recopilamos: versión de la aplicación, tipo de compilación, versión de macOS, idioma y resolución de pantalla. Sin nombres de proyectos, contenidos de archivos ni datos personales.";
 "Crash reports" = "Informes de errores";
 "Send crash reports and performance data. Requires restart to take effect." = "Envía informes de errores y datos de rendimiento. Requiere reiniciar la aplicación.";
-
-/* Settings - Danger Zone */
-"Danger Zone" = "Zona de peligro";
 "Bleeding edge" = "Últimas novedades";
 "Receive pre-release builds with the latest features. These may be less stable." = "Recibe versiones preliminares con las últimas funciones. Pueden ser menos estables.";
 "Clear project list" = "Borrar lista de proyectos";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -104,40 +104,31 @@
 "Installed" = "Installerad";
 "Install..." = "Installera...";
 
-/* Settings - Projects */
-"Projects" = "Projekt";
+/* Settings - General */
+"General" = "Allmänt";
 "Base directory" = "Baskatalog";
 "Change..." = "Ändra...";
 "Choose base directory for projects" = "Välj baskatalog för projekt";
 "Default location when adding new projects." = "Standardplats när nya projekt läggs till.";
 "Branch prefix" = "Grenprefix";
-
-/* Settings - Terminal & Browser */
-"Terminal & Browser" = "Terminal och webbläsare";
-"External Browser" = "Extern webbläsare";
+"Theme" = "Tema";
+"System" = "System";
+"Light" = "Ljust";
+"Dark" = "Mörkt";
 
 /* Settings - Coding Agent */
 "Agent Teams" = "Agentteam";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Aktiverar experimentell multi-agentkoordinering. Agenter kan skapa teammedlemmar, delegera uppgifter och samarbeta mellan arbetsflöden.";
 "Auto-rename branch" = "Byt namn på gren automatiskt";
 "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "Agenten byter namn på arbetsträdsgrenen för att matcha uppgiften vid den första förfrågan (t.ex. fix-login-timeout).";
+"External Browser" = "Extern webbläsare";
 
-/* Settings - Appearance */
-"Appearance" = "Utseende";
-"Theme" = "Tema";
-"System" = "System";
-"Light" = "Ljust";
-"Dark" = "Mörkt";
-
-/* Settings - Privacy & Logging */
-"Privacy & Logging" = "Integritet och loggning";
+/* Settings - Advanced */
+"Advanced" = "Avancerat";
 "Usage analytics" = "Användningsanalys";
 "Send anonymous usage data to help improve Factory Floor. We collect: app version, build type, macOS version, locale, and screen resolution. No project names, file contents, or personal data." = "Skicka anonym användningsdata för att hjälpa förbättra Factory Floor. Vi samlar in: appversion, byggtyp, macOS-version, språk och skärmupplösning. Inga projektnamn, filinnehåll eller personuppgifter.";
 "Crash reports" = "Kraschrapporter";
 "Send crash reports and performance data. Requires restart to take effect." = "Skicka kraschrapporter och prestandadata. Kräver omstart av appen.";
-
-/* Settings - Danger Zone */
-"Danger Zone" = "Riskzon";
 "Bleeding edge" = "Senaste versionen";
 "Receive pre-release builds with the latest features. These may be less stable." = "Ta emot förhandsversioner med de senaste funktionerna. Dessa kan vara mindre stabila.";
 "Clear project list" = "Rensa projektlistan";

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -1,5 +1,5 @@
 // ABOUTME: Application settings pane displayed in the detail area.
-// ABOUTME: Session, tools, default apps, and language settings.
+// ABOUTME: Environment, general, coding agent, and advanced settings.
 
 import SwiftUI
 
@@ -83,9 +83,9 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            // MARK: - Projects
+            // MARK: - General
 
-            Section("Projects") {
+            Section("General") {
                 HStack {
                     Text("Base directory")
                     Spacer()
@@ -134,6 +134,30 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
+                Picker("Theme", selection: $appearance) {
+                    Text("System").tag("system")
+                    Text("Light").tag("light")
+                    Text("Dark").tag("dark")
+                }
+                .onChange(of: appearance) { _, newValue in
+                    applyAppearance(newValue)
+                }
+
+                Picker("Language", selection: $languageOverride) {
+                    ForEach(availableLanguages, id: \.code) { lang in
+                        Text(lang.name).tag(lang.code)
+                    }
+                }
+                .onChange(of: languageOverride) { _, newValue in
+                    applyLanguage(newValue)
+                }
+
+                if !languageOverride.isEmpty {
+                    Text("Restart the app for the language change to take effect.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 Toggle("Confirm before quitting", isOn: $confirmQuit)
                 Text("Show a confirmation dialog when quitting with active workstreams.")
                     .font(.caption)
@@ -148,9 +172,24 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            // MARK: - Terminal & Browser
+            // MARK: - Coding Agent
 
-            Section("Terminal & Browser") {
+            Section("Coding Agent") {
+                Toggle("Bypass permission prompts", isOn: $bypassPermissions)
+                Text("When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking.")
+                    .font(.caption)
+                    .foregroundStyle(bypassPermissions ? .orange : .secondary)
+
+                Toggle("Agent Teams", isOn: $agentTeams)
+                Text("Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Auto-rename branch", isOn: $autoRenameBranch)
+                Text("The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 Toggle("Tmux Mode", isOn: $tmuxMode)
                     .disabled(!appEnv.toolStatus.tmux.isInstalled)
                 Text("Coding Agent sessions persist across app restarts. The Terminal tab is not affected. Sessions are lost on system restart.")
@@ -200,56 +239,9 @@ struct SettingsView: View {
                 }
             }
 
-            // MARK: - Coding Agent
+            // MARK: - Advanced
 
-            Section("Coding Agent") {
-                Toggle("Bypass permission prompts", isOn: $bypassPermissions)
-                Text("When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking.")
-                    .font(.caption)
-                    .foregroundStyle(bypassPermissions ? .orange : .secondary)
-
-                Toggle("Agent Teams", isOn: $agentTeams)
-                Text("Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Toggle("Auto-rename branch", isOn: $autoRenameBranch)
-                Text("The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout).")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            // MARK: - Appearance
-
-            Section("Appearance") {
-                Picker("Theme", selection: $appearance) {
-                    Text("System").tag("system")
-                    Text("Light").tag("light")
-                    Text("Dark").tag("dark")
-                }
-                .onChange(of: appearance) { _, newValue in
-                    applyAppearance(newValue)
-                }
-
-                Picker("Language", selection: $languageOverride) {
-                    ForEach(availableLanguages, id: \.code) { lang in
-                        Text(lang.name).tag(lang.code)
-                    }
-                }
-                .onChange(of: languageOverride) { _, newValue in
-                    applyLanguage(newValue)
-                }
-
-                if !languageOverride.isEmpty {
-                    Text("Restart the app for the language change to take effect.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            // MARK: - Privacy & Logging
-
-            Section("Privacy & Logging") {
+            Section("Advanced") {
                 Toggle("Usage analytics", isOn: $telemetryEnabled)
                 Text("Send anonymous usage data to help improve Factory Floor. We collect: app version, build type, macOS version, locale, and screen resolution. No project names, file contents, or personal data.")
                     .font(.caption)
@@ -264,11 +256,7 @@ struct SettingsView: View {
                 Text("Log setup, run, and teardown script output to files for debugging.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            }
 
-            // MARK: - Danger
-
-            Section("Danger Zone") {
                 Toggle("Bleeding edge", isOn: $bleedingEdge)
                 Text("Receive pre-release builds with the latest features. These may be less stable.")
                     .font(.caption)


### PR DESCRIPTION
## Summary
- Reorganize Settings view from 7 sections to 4: Environment, General, Coding Agent, Advanced
- Merge Projects + Appearance into General; Terminal & Browser into Coding Agent; Privacy & Logging + Danger Zone into Advanced
- Update all 4 locale files (en, es, sv, ca) with new section headers and remove stale keys

Closes #233

## Test plan
- [ ] Open Settings and verify 4 sections appear: Environment, General, Coding Agent, Advanced
- [ ] Verify all settings are present and functional in their new locations
- [ ] Switch language and confirm translated section headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)