### PR TITLE
fix: use interactive login shell for tool version manager support

### DIFF
--- a/Sources/Models/CommandBuilder.swift
+++ b/Sources/Models/CommandBuilder.swift
@@ -45,7 +45,7 @@ struct CommandBuilder {
         }
         let posixCmd = "\(primary) 2>\(stderrFile) || \(fallbackCmd)"
         let shCmd = "exec sh -c \(shellQuote(posixCmd))"
-        return "\(shell) -lc \(shellQuote(shCmd))"
+        return "\(shell) -lic \(shellQuote(shCmd))"
     }
 
     /// Path for capturing stderr from primary commands in fallback pipelines.

--- a/Sources/Models/CommandLineTools.swift
+++ b/Sources/Models/CommandLineTools.swift
@@ -71,7 +71,7 @@ enum CommandLineTools {
             let process = Process()
             let pipe = Pipe()
             process.executableURL = URL(fileURLWithPath: shell)
-            process.arguments = ["-l", "-c", "echo $PATH"]
+            process.arguments = ["-lic", "echo $PATH"]
             process.standardOutput = pipe
             process.standardError = FileHandle.nullDevice
             do {

--- a/Sources/Models/ScriptConfig.swift
+++ b/Sources/Models/ScriptConfig.swift
@@ -37,7 +37,7 @@ struct ScriptConfig {
         guard let teardown = config.teardown else { return }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: CommandBuilder.userShell)
-        process.arguments = ["-lc", teardown]
+        process.arguments = ["-lic", teardown]
         process.currentDirectoryURL = URL(fileURLWithPath: directory)
 
         process.standardOutput = FileHandle.nullDevice

--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -79,7 +79,7 @@ enum TmuxSession {
         let setup = serverSetupCommand(tmuxPath: tmuxPath, configPath: configPath)
         let posixCmd = shellEscape("\(setup); exec \(tmuxCmd)")
         let shCmd = "exec sh -c \(posixCmd)"
-        return "\(shell) -lc \(shellEscape(shCmd))"
+        return "\(shell) -lic \(shellEscape(shCmd))"
     }
 
     /// Kill a tmux session by name.

--- a/Tests/CommandBuilderTests.swift
+++ b/Tests/CommandBuilderTests.swift
@@ -98,7 +98,7 @@ final class CommandBuilderTests: XCTestCase {
 
     func testWithFallbackBasic() {
         let result = CommandBuilder.withFallback("cmd1", "cmd2", shell: "/bin/zsh")
-        XCTAssertTrue(result.hasPrefix("/bin/zsh -lc "), "Should use login shell")
+        XCTAssertTrue(result.hasPrefix("/bin/zsh -lic "), "Should use interactive login shell")
         XCTAssertTrue(result.contains("exec sh -c"), "Should use sh for POSIX syntax")
         XCTAssertTrue(result.contains("cmd1 2>"), "Primary stderr should be redirected to file")
         XCTAssertFalse(result.contains("2>/dev/null"), "Stderr should go to a file, not /dev/null")
@@ -117,7 +117,7 @@ final class CommandBuilderTests: XCTestCase {
     func testWithFallbackMessageWithSpecialChars() {
         let result = CommandBuilder.withFallback("cmd1", "cmd2", message: "it's failing", shell: "/bin/zsh")
         XCTAssertTrue(result.contains("echo"), "Should contain echo")
-        XCTAssertTrue(result.hasPrefix("/bin/zsh -lc "), "Should use login shell")
+        XCTAssertTrue(result.hasPrefix("/bin/zsh -lic "), "Should use interactive login shell")
         XCTAssertTrue(result.contains("exec sh -c"), "Should use sh for POSIX syntax")
     }
 
@@ -129,7 +129,7 @@ final class CommandBuilderTests: XCTestCase {
         cmd2.option("--session-id", "abc-123")
 
         let result = CommandBuilder.withFallback(cmd1.command, cmd2.command, shell: "/bin/zsh")
-        XCTAssertTrue(result.hasPrefix("/bin/zsh -lc '"))
+        XCTAssertTrue(result.hasPrefix("/bin/zsh -lic '"))
         XCTAssertTrue(result.contains("exec sh -c"))
         XCTAssertTrue(result.contains("--name"))
         XCTAssertTrue(result.contains("--session-id"))

--- a/Tests/TmuxSessionTests.swift
+++ b/Tests/TmuxSessionTests.swift
@@ -64,7 +64,7 @@ final class TmuxSessionTests: XCTestCase {
             shell: "/bin/zsh"
         )
 
-        XCTAssertTrue(command.hasPrefix("/bin/zsh -lc "), "Should use login shell for PATH")
+        XCTAssertTrue(command.hasPrefix("/bin/zsh -lic "), "Should use interactive login shell for PATH")
         XCTAssertTrue(command.contains("exec sh -c"), "Should use sh for POSIX syntax")
         XCTAssertTrue(command.contains("start-server"))
         XCTAssertTrue(command.contains("source-file"))


### PR DESCRIPTION
## Summary
- Switches all shell invocations from `-lc` (login, non-interactive) to `-lic` (login, interactive) so that tool version managers (mise, nvm, fnm, asdf) that activate in `.zshrc`/`.bashrc`/`config.fish` are properly initialized
- Fixes Claude Code failing to start for users whose Node.js is managed by these tools (e.g., Node v25 causing `TypeError: Cannot read properties of undefined`)
- Applies to: agent command builder, tmux wrapper, teardown scripts, and PATH resolution

## Test plan
- [x] All 90 tests pass
- [ ] Verify Claude Code starts correctly with mise-managed Node.js
- [ ] Verify tmux mode works with mise-managed tools
- [ ] Test with zsh, bash, and fish shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)