### PR TITLE
fix: fade onboarding content so skyline stays visible

### DIFF
--- a/Sources/Views/OnboardingView.swift
+++ b/Sources/Views/OnboardingView.swift
@@ -128,6 +128,13 @@ struct OnboardingView: View {
             .frame(maxWidth: .infinity)
             .padding(.bottom, 24)
         }
+        .mask(
+            VStack(spacing: 0) {
+                Rectangle()
+                LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+                    .frame(height: 120)
+            }
+        )
         .background(alignment: .bottom) {
             PoblenouSkylineView()
                 .padding(.horizontal, 40)


### PR DESCRIPTION
## Summary
- Adds a gradient mask to the bottom of the onboarding ScrollView so content fades to transparent
- The Poblenou skyline behind the content remains visible even when the window is small

## Test plan
- [ ] Resize the window vertically and confirm the skyline is visible through the faded content
- [ ] Scroll the onboarding view and verify the fade effect looks natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)