### PR TITLE
fix: create empty initial commit on git init to enable worktrees

### DIFF
--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -36,9 +36,12 @@ enum GitOperations {
         return FileManager.default.fileExists(atPath: gitDir.path)
     }
 
-    /// Initialize a git repo at the given path.
+    /// Initialize a git repo at the given path with an empty initial commit.
     static func initRepo(at path: String) -> Bool {
-        return run(args: ["init"], in: path) != nil
+        guard run(args: ["init"], in: path) != nil else { return false }
+        // Create an empty commit so the repo has a HEAD ref, which is
+        // required for worktree creation.
+        return run(args: ["commit", "--allow-empty", "-m", "Initial commit"], in: path) != nil
     }
 
     /// Get repo information for display.


### PR DESCRIPTION
## Summary
- New repos created via the app had no commits, preventing worktree creation
- `initRepo` now runs `git commit --allow-empty` after `git init` so the repo has a HEAD ref immediately

## Test plan
- [ ] Create a new project in the app and verify a workstream can be created immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)