### PR TITLE
perf: show workstream UI instantly during worktree creation

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Stop" = "Atura";
 
 "Restarting..." = "Reiniciant...";
+"Preparing workstream..." = "Preparant el flux de treball...";
 
 /* Update Banner */
 "v%@ available" = "v%@ disponible";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Stop" = "Stop";
 
 "Restarting..." = "Restarting...";
+"Preparing workstream..." = "Preparing workstream...";
 
 /* Update Banner */
 "v%@ available" = "v%@ available";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Stop" = "Detener";
 
 "Restarting..." = "Reiniciando...";
+"Preparing workstream..." = "Preparando flujo de trabajo...";
 
 /* Update Banner */
 "v%@ available" = "v%@ disponible";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Stop" = "Stoppa";
 
 "Restarting..." = "Startar om...";
+"Preparing workstream..." = "Förbereder arbetsflöde...";
 
 /* Update Banner */
 "v%@ available" = "v%@ tillgänglig";

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -8,6 +8,8 @@ private let logger = Logger(subsystem: "factoryfloor", category: "content-view")
 
 extension Notification.Name {
     static let workstreamCreated = Notification.Name("factoryfloor.workstreamCreated")
+    static let workstreamWorktreeReady = Notification.Name("factoryfloor.workstreamWorktreeReady")
+    static let workstreamCreationFailed = Notification.Name("factoryfloor.workstreamCreationFailed")
     static let projectCreated = Notification.Name("factoryfloor.projectCreated")
 }
 
@@ -81,17 +83,29 @@ struct ContentView: View {
                 .navigationTitle("Help")
                 .navigationSubtitle(AppConstants.appName)
         } else if let workstream = activeWorkstream, let project = activeProject {
-            TerminalContainerView(
-                workstreamID: workstream.id,
-                workingDirectory: workstream.workingDirectory(projectDirectory: project.directory),
-                projectDirectory: project.directory,
-                projectName: project.name,
-                workstreamName: workstream.name,
-                bypassPermissions: workstream.bypassPermissions
-            )
-            .id(workstream.id)
-            .navigationTitle(workstream.name)
-            .navigationSubtitle(project.name)
+            if workstream.worktreePath != nil {
+                TerminalContainerView(
+                    workstreamID: workstream.id,
+                    workingDirectory: workstream.workingDirectory(projectDirectory: project.directory),
+                    projectDirectory: project.directory,
+                    projectName: project.name,
+                    workstreamName: workstream.name,
+                    bypassPermissions: workstream.bypassPermissions
+                )
+                .id(workstream.id)
+                .navigationTitle(workstream.name)
+                .navigationSubtitle(project.name)
+            } else {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Preparing workstream...")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .navigationTitle(workstream.name)
+                .navigationSubtitle(project.name)
+            }
         } else if let project = activeProject,
                   let projectIndex = projects.firstIndex(where: { $0.id == project.id })
         {
@@ -248,6 +262,31 @@ struct ContentView: View {
             selection = .workstream(workstream.id)
             ProjectStore.save(projects)
             logger.warning("[FF] workstreamCreated notification handled: \(workstream.name, privacy: .public)")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .workstreamWorktreeReady)) { notification in
+            guard let info = notification.userInfo,
+                  let workstreamID = info["workstreamID"] as? UUID,
+                  let worktreePath = info["worktreePath"] as? String else { return }
+            for pi in projects.indices {
+                if let wi = projects[pi].workstreams.firstIndex(where: { $0.id == workstreamID }) {
+                    projects[pi].workstreams[wi].worktreePath = worktreePath
+                    ProjectStore.save(projects)
+                    logger.warning("[FF] workstreamWorktreeReady: updated \(workstreamID, privacy: .public) with path \(worktreePath, privacy: .public)")
+                    return
+                }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .workstreamCreationFailed)) { notification in
+            guard let info = notification.userInfo,
+                  let projectID = info["projectID"] as? UUID,
+                  let workstreamID = info["workstreamID"] as? UUID,
+                  let pi = projects.firstIndex(where: { $0.id == projectID }) else { return }
+            projects[pi].workstreams.removeAll { $0.id == workstreamID }
+            if case let .workstream(selectedID) = selection, selectedID == workstreamID {
+                selection = .project(projectID)
+            }
+            ProjectStore.save(projects)
+            logger.warning("[FF] workstreamCreationFailed: removed \(workstreamID, privacy: .public)")
         }
         .onReceive(NotificationCenter.default.publisher(for: .projectCreated)) { notification in
             guard let project = notification.userInfo?["project"] as? Project else { return }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -361,21 +361,8 @@ struct ProjectSidebar: View {
         let name = NameGenerator.generate(avoiding: existingNames)
         logger.warning("[FF] addWorkstream: generated name=\(name, privacy: .public)")
 
-        guard let worktreePath = GitOperations.createWorktree(
-            projectPath: project.directory,
-            projectName: project.name,
-            workstreamName: name,
-            branchPrefix: branchPrefix,
-            symlinkEnv: symlinkEnv
-        ) else {
-            logger.warning("[FF] addWorkstream: createWorktree FAILED")
-            showWorktreeError = true
-            return
-        }
-        logger.warning("[FF] addWorkstream: worktree created at \(worktreePath, privacy: .public)")
-
         let bypass = bypassPermissions ?? defaultBypass
-        let workstream = Workstream(name: name, worktreePath: worktreePath, bypassPermissions: bypass)
+        let workstream = Workstream(name: name, worktreePath: nil, bypassPermissions: bypass)
         expandedProjects.insert(projectID)
         NotificationCenter.default.post(
             name: .workstreamCreated,
@@ -383,7 +370,41 @@ struct ProjectSidebar: View {
             userInfo: ["projectID": projectID, "workstream": workstream]
         )
         rebuildIndices()
-        logger.warning("[FF] addWorkstream: done, posted notification")
+        logger.warning("[FF] addWorkstream: posted notification (optimistic), starting background worktree creation")
+
+        let projectPath = project.directory
+        let projectName = project.name
+        let prefix = branchPrefix
+        let symlink = symlinkEnv
+        let workstreamID = workstream.id
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let worktreePath = GitOperations.createWorktree(
+                projectPath: projectPath,
+                projectName: projectName,
+                workstreamName: name,
+                branchPrefix: prefix,
+                symlinkEnv: symlink
+            )
+            DispatchQueue.main.async {
+                if let worktreePath {
+                    logger.warning("[FF] addWorkstream: worktree created at \(worktreePath, privacy: .public)")
+                    NotificationCenter.default.post(
+                        name: .workstreamWorktreeReady,
+                        object: nil,
+                        userInfo: ["workstreamID": workstreamID, "worktreePath": worktreePath]
+                    )
+                } else {
+                    logger.warning("[FF] addWorkstream: createWorktree FAILED, rolling back")
+                    NotificationCenter.default.post(
+                        name: .workstreamCreationFailed,
+                        object: nil,
+                        userInfo: ["projectID": projectID, "workstreamID": workstreamID]
+                    )
+                    showWorktreeError = true
+                }
+            }
+        }
     }
 
     @EnvironmentObject private var surfaceCache: TerminalSurfaceCache


### PR DESCRIPTION
## Summary
- Shows the new workstream in the sidebar immediately when clicking "+" (optimistic UI)
- Dispatches worktree creation to a background queue, shows a spinner in the content area while preparing
- On failure, rolls back the workstream from the UI and shows the existing error alert

Closes #254

## Test plan
- [ ] Click "+" - workstream should appear in sidebar instantly with no lag
- [ ] While worktree is being created, verify "Preparing workstream..." spinner is shown
- [ ] After worktree is ready, verify the agent terminal loads normally
- [ ] Force a failure (e.g. branch conflict) - verify workstream is removed from sidebar and error alert shows
- [ ] Verify rapid clicking "+" multiple times doesn't cause issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)