### PR TITLE
docs: document .factoryfloor.json script configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Factory Floor is a native macOS app built on [Ghostty](https://ghostty.org)'s GP
 
 ### Script Configuration
 
-Add a `.factoryfloor.json` to your project root:
+Add a `.factoryfloor.json` to your project root to automate your workstream lifecycle. All fields are optional.
 
 ```json
 {
@@ -69,6 +69,14 @@ Add a `.factoryfloor.json` to your project root:
   "teardown": "docker-compose down"
 }
 ```
+
+| Hook | When it runs | Example use case |
+|---|---|---|
+| `setup` | Once, when a workstream is created | Install deps, copy .env, run build steps |
+| `run` | On demand via the Environment tab | Start dev server, docker-compose up |
+| `teardown` | When a workstream is archived | docker-compose down, clean temp files |
+
+Scripts run in the workstream directory using your login shell. The `run` script is wrapped in the `ff-run` launcher for automatic port detection.
 
 ### Environment Variables
 

--- a/website/i18n/ca.toml
+++ b/website/i18n/ca.toml
@@ -91,6 +91,18 @@ other = "Automatitza el cicle de vida dels workstreams amb scripts de setup, run
 other = "Afegeix un"
 [config_or_use]
 other = "a l'arrel del projecte."
+[config_hook]
+other = "Hook"
+[config_when]
+other = "Quan s'executa"
+[config_setup_desc]
+other = "Un cop, quan es crea un workstream. Per instal·lar dependències o passos de build."
+[config_run_desc]
+other = "Sota demanda des de la pestanya Environment. Embolcallat amb ff-run per detectar ports automàticament."
+[config_teardown_desc]
+other = "Quan s'arxiva un workstream. Per netejar recursos com aturar contenidors."
+[config_optional_note]
+other = "Tots els camps són opcionals. Els scripts s'executen al directori del workstream amb el teu shell de login."
 
 # Env vars
 [env_label]

--- a/website/i18n/en.toml
+++ b/website/i18n/en.toml
@@ -91,6 +91,18 @@ other = "Automate your workstream lifecycle with setup, run, and teardown script
 other = "Add a"
 [config_or_use]
 other = "to your project root."
+[config_hook]
+other = "Hook"
+[config_when]
+other = "When it runs"
+[config_setup_desc]
+other = "Once, when a workstream is created. Use for installing dependencies or build steps."
+[config_run_desc]
+other = "On demand via the Environment tab. Wrapped in ff-run for automatic port detection."
+[config_teardown_desc]
+other = "When a workstream is archived. Use for cleanup like stopping containers."
+[config_optional_note]
+other = "All fields are optional. Scripts run in the workstream directory using your login shell."
 
 # Env vars
 [env_label]

--- a/website/i18n/es.toml
+++ b/website/i18n/es.toml
@@ -87,6 +87,18 @@ other = "Automatiza el ciclo de vida de workstreams con scripts de setup, run y 
 other = "Añade un"
 [config_or_use]
 other = "a la raíz de tu proyecto."
+[config_hook]
+other = "Hook"
+[config_when]
+other = "Cuándo se ejecuta"
+[config_setup_desc]
+other = "Una vez, al crear un workstream. Para instalar dependencias o pasos de build."
+[config_run_desc]
+other = "Bajo demanda desde la pestaña Environment. Envuelto en ff-run para detección automática de puertos."
+[config_teardown_desc]
+other = "Al archivar un workstream. Para limpiar recursos como detener contenedores."
+[config_optional_note]
+other = "Todos los campos son opcionales. Los scripts se ejecutan en el directorio del workstream con tu shell de login."
 
 [env_label]
 other = "Entorno"

--- a/website/i18n/sv.toml
+++ b/website/i18n/sv.toml
@@ -86,6 +86,18 @@ other = "Automatisera workstream-livscykeln med setup, run och teardown scripts.
 other = "Lägg till en"
 [config_or_use]
 other = "i din projektrot."
+[config_hook]
+other = "Hook"
+[config_when]
+other = "När det körs"
+[config_setup_desc]
+other = "En gång, när en workstream skapas. För att installera dependencies eller bygga."
+[config_run_desc]
+other = "On demand via Environment-tabben. Wrappat i ff-run för automatisk portdetektering."
+[config_teardown_desc]
+other = "När en workstream arkiveras. För att städa resurser som att stoppa containrar."
+[config_optional_note]
+other = "Alla fält är valfria. Scripts körs i workstreamens directory med ditt login shell."
 
 [env_label]
 other = "Environment"

--- a/website/layouts/partials/config.html
+++ b/website/layouts/partials/config.html
@@ -23,5 +23,21 @@
 <span class="text-fg-muted">}</span></code></pre>
       </div>
     </div>
+    <div class="mt-10 rounded-xl overflow-hidden border border-fg-faint bg-bg-surface max-w-[560px] reveal">
+      <table class="w-full text-left">
+        <thead>
+          <tr class="border-b border-fg-faint bg-bg-elevated">
+            <th class="px-6 py-3 font-mono text-xs font-semibold text-fg-muted">{{ T "config_hook" }}</th>
+            <th class="px-6 py-3 font-mono text-xs font-semibold text-fg-muted">{{ T "config_when" }}</th>
+          </tr>
+        </thead>
+        <tbody class="font-mono text-sm">
+          <tr class="border-b border-fg-faint"><td class="px-6 py-3 text-code-key text-xs">setup</td><td class="px-6 py-3 font-sans text-sm text-fg-dim">{{ T "config_setup_desc" }}</td></tr>
+          <tr class="border-b border-fg-faint"><td class="px-6 py-3 text-code-key text-xs">run</td><td class="px-6 py-3 font-sans text-sm text-fg-dim">{{ T "config_run_desc" }}</td></tr>
+          <tr><td class="px-6 py-3 text-code-key text-xs">teardown</td><td class="px-6 py-3 font-sans text-sm text-fg-dim">{{ T "config_teardown_desc" }}</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="mt-4 text-fg-muted text-sm max-w-[560px] reveal">{{ T "config_optional_note" }}</p>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Expands README script configuration section with a hooks reference table and details
- Adds a styled table to the website config section showing each hook and when it runs
- Adds i18n translations (en, ca, es, sv) for all new website content

Closes #255

## Test plan
- [ ] Review README changes render correctly on GitHub
- [ ] Run `hugo server` in `website/` and verify the config section table renders properly
- [ ] Verify all 4 language versions display correctly (en, ca, es, sv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)