### PR TITLE
feat: support conductor.json and superset config as script fallbacks

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -248,3 +248,4 @@
 /* Update Banner */
 "v%@ available" = "v%@ disponible";
 "Release Notes" = "Notes de la versió";
+"Using scripts from %@" = "S'utilitzen els scripts de %@";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -248,3 +248,4 @@
 /* Update Banner */
 "v%@ available" = "v%@ available";
 "Release Notes" = "Release Notes";
+"Using scripts from %@" = "Using scripts from %@";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -248,3 +248,4 @@
 /* Update Banner */
 "v%@ available" = "v%@ disponible";
 "Release Notes" = "Notas de la versión";
+"Using scripts from %@" = "Usando scripts de %@";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -248,3 +248,4 @@
 /* Update Banner */
 "v%@ available" = "v%@ tillgänglig";
 "Release Notes" = "Versionsanteckningar";
+"Using scripts from %@" = "Använder skript från %@";

--- a/Sources/Models/ScriptConfig.swift
+++ b/Sources/Models/ScriptConfig.swift
@@ -1,5 +1,5 @@
 // ABOUTME: Loads setup/run/teardown script configuration from project config files.
-// ABOUTME: Resolves from .factoryfloor.json or .factoryfloor/config.json.
+// ABOUTME: Resolves from .factoryfloor.json, conductor.json, or .superset/config.json.
 
 import Foundation
 import os
@@ -16,15 +16,27 @@ struct ScriptConfig {
     static let empty = ScriptConfig(setup: nil, run: nil, teardown: nil, source: nil, loadError: nil)
 
     /// Load script config for a project directory.
+    /// Checks .factoryfloor.json first, then conductor.json, then .superset/config.json.
     static func load(from directory: String) -> ScriptConfig {
-        let path = URL(fileURLWithPath: directory).appendingPathComponent(".factoryfloor.json").path
-        guard FileManager.default.fileExists(atPath: path) else { return .empty }
-        do {
-            return try loadFF2(path)
-        } catch {
-            logger.error("Failed to load \(path): \(error.localizedDescription)")
-            return ScriptConfig(setup: nil, run: nil, teardown: nil, source: URL(fileURLWithPath: path).lastPathComponent, loadError: error.localizedDescription)
+        let dir = URL(fileURLWithPath: directory)
+
+        let candidates: [(path: String, source: String, loader: (String) throws -> ScriptConfig)] = [
+            (dir.appendingPathComponent(".factoryfloor.json").path, ".factoryfloor.json", loadFF2),
+            (dir.appendingPathComponent("conductor.json").path, "conductor.json", loadConductor),
+            (dir.appendingPathComponent(".superset/config.json").path, ".superset/config.json", loadSuperset),
+        ]
+
+        for candidate in candidates {
+            guard FileManager.default.fileExists(atPath: candidate.path) else { continue }
+            do {
+                return try candidate.loader(candidate.path)
+            } catch {
+                logger.error("Failed to load \(candidate.path): \(error.localizedDescription)")
+                return ScriptConfig(setup: nil, run: nil, teardown: nil, source: candidate.source, loadError: error.localizedDescription)
+            }
         }
+
+        return .empty
     }
 
     var hasAnyScript: Bool {
@@ -73,7 +85,40 @@ struct ScriptConfig {
         return ScriptConfig(setup: nonEmpty(setup), run: nonEmpty(run), teardown: nonEmpty(teardown), source: URL(fileURLWithPath: path).lastPathComponent, loadError: nil)
     }
 
+    /// conductor.json: { "scripts": { "setup": "cmd", "run": "cmd", "archive": "cmd" } }
+    private static func loadConductor(_ path: String) throws -> ScriptConfig {
+        let dict = try loadJSON(path)
+        guard let scripts = dict["scripts"] as? [String: Any] else { return .empty }
+        let setup = scripts["setup"] as? String
+        let run = scripts["run"] as? String
+        let teardown = scripts["archive"] as? String
+        guard setup != nil || run != nil || teardown != nil else { return .empty }
+        return ScriptConfig(setup: nonEmpty(setup), run: nonEmpty(run), teardown: nonEmpty(teardown), source: "conductor.json", loadError: nil)
+    }
+
+    /// .superset/config.json: { "setup": ["cmd1", "cmd2"], "run": ["cmd"], "teardown": ["cmd"] }
+    private static func loadSuperset(_ path: String) throws -> ScriptConfig {
+        let dict = try loadJSON(path)
+        let setup = joinCommands(dict["setup"])
+        let run = joinCommands(dict["run"])
+        let teardown = joinCommands(dict["teardown"])
+        guard setup != nil || run != nil || teardown != nil else { return .empty }
+        return ScriptConfig(setup: setup, run: run, teardown: teardown, source: ".superset/config.json", loadError: nil)
+    }
+
     // MARK: - Helpers
+
+    /// Join a string array into a single command with &&, or return a plain string.
+    private static func joinCommands(_ value: Any?) -> String? {
+        if let array = value as? [String] {
+            let joined = array.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }.joined(separator: " && ")
+            return nonEmpty(joined)
+        }
+        if let str = value as? String {
+            return nonEmpty(str)
+        }
+        return nil
+    }
 
     private static func loadJSON(_ path: String) throws -> [String: Any] {
         guard let data = FileManager.default.contents(atPath: path) else {

--- a/Sources/Views/EnvironmentTabView.swift
+++ b/Sources/Views/EnvironmentTabView.swift
@@ -49,6 +49,10 @@ struct EnvironmentTabView: View {
                 configErrorBanner(error: error)
                 Divider()
             }
+            if let source = scriptConfig.source, source != ".factoryfloor.json" {
+                configSourceBanner(source: source)
+                Divider()
+            }
             environmentContent
         }
     }
@@ -239,6 +243,19 @@ struct EnvironmentTabView: View {
         }
         .padding(10)
         .background(Color.yellow.opacity(0.08))
+    }
+
+    private func configSourceBanner(source: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.blue)
+            Text(String(format: NSLocalizedString("Using scripts from %@", comment: ""), source))
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(10)
+        .background(Color.blue.opacity(0.05))
     }
 
     private func scriptInstructions(title: String) -> some View {

--- a/Tests/ScriptConfigTests.swift
+++ b/Tests/ScriptConfigTests.swift
@@ -1,0 +1,150 @@
+// ABOUTME: Tests for ScriptConfig loading from multiple config file formats.
+// ABOUTME: Validates priority order and parsing of factoryfloor, conductor, and superset configs.
+
+@testable import FactoryFloor
+import XCTest
+
+final class ScriptConfigTests: XCTestCase {
+    private var tmpDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tmpDir)
+        super.tearDown()
+    }
+
+    // MARK: - Empty directory
+
+    func testEmptyDirectoryReturnsEmpty() {
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertNil(config.setup)
+        XCTAssertNil(config.run)
+        XCTAssertNil(config.teardown)
+        XCTAssertNil(config.source)
+        XCTAssertFalse(config.hasAnyScript)
+    }
+
+    // MARK: - .factoryfloor.json (primary)
+
+    func testFactoryFloorJSON() {
+        writeJSON(".factoryfloor.json", ["setup": "npm install", "run": "npm start"])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.setup, "npm install")
+        XCTAssertEqual(config.run, "npm start")
+        XCTAssertNil(config.teardown)
+        XCTAssertEqual(config.source, ".factoryfloor.json")
+    }
+
+    func testFactoryFloorTakesPriorityOverConductor() {
+        writeJSON(".factoryfloor.json", ["run": "ff-run"])
+        writeJSON("conductor.json", ["scripts": ["run": "conductor-run"]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.run, "ff-run")
+        XCTAssertEqual(config.source, ".factoryfloor.json")
+    }
+
+    func testFactoryFloorTakesPriorityOverSuperset() throws {
+        writeJSON(".factoryfloor.json", ["run": "ff-run"])
+        let supersetDir = tmpDir.appendingPathComponent(".superset")
+        try FileManager.default.createDirectory(at: supersetDir, withIntermediateDirectories: true)
+        writeJSON(".superset/config.json", ["run": ["superset-run"]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.run, "ff-run")
+        XCTAssertEqual(config.source, ".factoryfloor.json")
+    }
+
+    // MARK: - conductor.json (fallback)
+
+    func testConductorJSON() {
+        writeJSON("conductor.json", ["scripts": ["setup": "make build", "run": "make serve", "archive": "make clean"]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.setup, "make build")
+        XCTAssertEqual(config.run, "make serve")
+        XCTAssertEqual(config.teardown, "make clean")
+        XCTAssertEqual(config.source, "conductor.json")
+    }
+
+    func testConductorMapsArchiveToTeardown() {
+        writeJSON("conductor.json", ["scripts": ["archive": "rm -rf dist"]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.teardown, "rm -rf dist")
+        XCTAssertNil(config.setup)
+        XCTAssertNil(config.run)
+    }
+
+    func testConductorWithoutScriptsKeyReturnsEmpty() {
+        writeJSON("conductor.json", ["setup": "npm install"])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertFalse(config.hasAnyScript)
+    }
+
+    func testConductorTakesPriorityOverSuperset() throws {
+        writeJSON("conductor.json", ["scripts": ["run": "conductor-run"]])
+        let supersetDir = tmpDir.appendingPathComponent(".superset")
+        try FileManager.default.createDirectory(at: supersetDir, withIntermediateDirectories: true)
+        writeJSON(".superset/config.json", ["run": ["superset-run"]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.run, "conductor-run")
+        XCTAssertEqual(config.source, "conductor.json")
+    }
+
+    // MARK: - .superset/config.json (fallback)
+
+    func testSupersetJSON() throws {
+        let supersetDir = tmpDir.appendingPathComponent(".superset")
+        try FileManager.default.createDirectory(at: supersetDir, withIntermediateDirectories: true)
+        writeJSON(".superset/config.json", ["setup": ["npm install", "cp .env.example .env"], "run": ["npm run dev"], "teardown": ["rm -rf node_modules"]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.setup, "npm install && cp .env.example .env")
+        XCTAssertEqual(config.run, "npm run dev")
+        XCTAssertEqual(config.teardown, "rm -rf node_modules")
+        XCTAssertEqual(config.source, ".superset/config.json")
+    }
+
+    func testSupersetFiltersEmptyStrings() throws {
+        let supersetDir = tmpDir.appendingPathComponent(".superset")
+        try FileManager.default.createDirectory(at: supersetDir, withIntermediateDirectories: true)
+        writeJSON(".superset/config.json", ["run": ["npm start", "", "  "]])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.run, "npm start")
+    }
+
+    func testSupersetAcceptsPlainStrings() throws {
+        let supersetDir = tmpDir.appendingPathComponent(".superset")
+        try FileManager.default.createDirectory(at: supersetDir, withIntermediateDirectories: true)
+        writeJSON(".superset/config.json", ["run": "npm start"])
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertEqual(config.run, "npm start")
+    }
+
+    // MARK: - Error handling
+
+    func testInvalidJSONReportsError() {
+        let path = tmpDir.appendingPathComponent(".factoryfloor.json").path
+        FileManager.default.createFile(atPath: path, contents: "not json".data(using: .utf8))
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertNotNil(config.loadError)
+        XCTAssertEqual(config.source, ".factoryfloor.json")
+    }
+
+    func testInvalidConductorJSONReportsError() {
+        let path = tmpDir.appendingPathComponent("conductor.json").path
+        FileManager.default.createFile(atPath: path, contents: "not json".data(using: .utf8))
+        let config = ScriptConfig.load(from: tmpDir.path)
+        XCTAssertNotNil(config.loadError)
+        XCTAssertEqual(config.source, "conductor.json")
+    }
+
+    // MARK: - Helpers
+
+    private func writeJSON(_ name: String, _ dict: [String: Any]) {
+        let path = tmpDir.appendingPathComponent(name).path
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        FileManager.default.createFile(atPath: path, contents: data)
+    }
+}


### PR DESCRIPTION
## Summary
- When `.factoryfloor.json` doesn't exist, checks for `conductor.json` then `.superset/config.json` as fallbacks
- Maps conductor's `scripts.archive` to `teardown`, and joins superset's string arrays with `&&`
- Shows a subtle banner in the Environment tab indicating which config source is active
- Adds 13 unit tests covering all formats, priority, and error handling

Closes #256

## Test plan
- [ ] Project with `.factoryfloor.json` - verify it's still used (no change)
- [ ] Project with `conductor.json` only - verify scripts load, `archive` maps to teardown
- [ ] Project with `.superset/config.json` only - verify array commands are joined with `&&`
- [ ] Project with both `.factoryfloor.json` and `conductor.json` - verify `.factoryfloor.json` wins
- [ ] Verify "Using scripts from conductor.json" banner shows in Environment tab
- [ ] Run `./scripts/dev.sh test` - all 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)