### PR TITLE
fix: resolve build error and warnings

### DIFF
--- a/Sources/Terminal/TerminalApp.swift
+++ b/Sources/Terminal/TerminalApp.swift
@@ -129,20 +129,22 @@ private func writeClipboardText(_ plainText: String) {
 }
 
 private func sendDesktopNotification(title: String, body: String) {
-    guard !NSApp.isActive else { return }
-    let center = UNUserNotificationCenter.current()
-    let content = UNMutableNotificationContent()
-    content.title = title
-    content.body = body
-    content.sound = UNNotificationSound(named: UNNotificationSoundName("notification.wav"))
-    let request = UNNotificationRequest(
-        identifier: UUID().uuidString,
-        content: content,
-        trigger: nil
-    )
-    center.add(request) { error in
-        if let error {
-            logger.warning("Failed to deliver notification: \(error.localizedDescription)")
+    DispatchQueue.main.async {
+        guard !NSApp.isActive else { return }
+        let center = UNUserNotificationCenter.current()
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = UNNotificationSound(named: UNNotificationSoundName("notification.wav"))
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        center.add(request) { error in
+            if let error {
+                logger.warning("Failed to deliver notification: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -196,6 +196,61 @@ struct ContentView: View {
     }
 
     private var navigationView: some View {
+        navigationViewBase
+            .onChange(of: appEnvironment.missingProjectIDs) { _, missing in
+                guard !missing.isEmpty else { return }
+                logger.warning("[FF] missingProjectIDs changed: \(missing.count, privacy: .public) missing, \(projects.count, privacy: .public) total projects")
+                let names = projects.filter { missing.contains($0.id) }.map(\.name)
+                logger.warning("[FF] removing projects: \(names, privacy: .public)")
+                for id in missing {
+                    if let project = projects.first(where: { $0.id == id }) {
+                        for ws in project.workstreams {
+                            surfaceCache.removeWorkstreamSurfaces(for: ws.id)
+                        }
+                    }
+                }
+                projects.removeAll { missing.contains($0.id) }
+                if let sel = selection, case let .project(pid) = sel, missing.contains(pid) {
+                    selection = nil
+                }
+                if let sel = selection, case .workstream = sel, activeProject == nil {
+                    selection = nil
+                }
+                ProjectStore.save(projects)
+                removedProjectNames = names
+            }
+            .onChange(of: selection) { oldValue, newValue in
+                logger.warning("[FF] selection changed: \(String(describing: oldValue), privacy: .public) -> \(String(describing: newValue), privacy: .public)")
+                if newValue == .settings || newValue == .help {
+                    selectionBeforeSettings = oldValue
+                }
+                // Don't persist settings/help as saved selection
+                if newValue != .settings && newValue != .help {
+                    newValue?.save()
+                }
+            }
+            .onKeyPress(.escape) {
+                if selection == .settings || selection == .help {
+                    selection = selectionBeforeSettings
+                    return .handled
+                }
+                return .ignored
+            }
+            .onAppear {
+                // Intercept Cmd+W at the app level to close tabs instead of the window
+                guard !keyMonitorInstalled else { return }
+                keyMonitorInstalled = true
+                NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                    if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "w" {
+                        NotificationCenter.default.post(name: .closeTerminal, object: nil)
+                        return nil // swallow the event
+                    }
+                    return event
+                }
+            }
+    }
+
+    private var navigationViewBase: some View {
         NavigationSplitView {
             ProjectSidebar(
                 projects: $projectList.items,
@@ -303,57 +358,6 @@ struct ContentView: View {
         }
         .onReceive(Timer.publish(every: 6 * 60 * 60, on: .main, in: .common).autoconnect()) { _ in
             updateChecker.check()
-        }
-        .onChange(of: appEnvironment.missingProjectIDs) { _, missing in
-            guard !missing.isEmpty else { return }
-            logger.warning("[FF] missingProjectIDs changed: \(missing.count, privacy: .public) missing, \(projects.count, privacy: .public) total projects")
-            let names = projects.filter { missing.contains($0.id) }.map(\.name)
-            logger.warning("[FF] removing projects: \(names, privacy: .public)")
-            for id in missing {
-                if let project = projects.first(where: { $0.id == id }) {
-                    for ws in project.workstreams {
-                        surfaceCache.removeWorkstreamSurfaces(for: ws.id)
-                    }
-                }
-            }
-            projects.removeAll { missing.contains($0.id) }
-            if let sel = selection, case let .project(pid) = sel, missing.contains(pid) {
-                selection = nil
-            }
-            if let sel = selection, case .workstream = sel, activeProject == nil {
-                selection = nil
-            }
-            ProjectStore.save(projects)
-            removedProjectNames = names
-        }
-        .onChange(of: selection) { oldValue, newValue in
-            logger.warning("[FF] selection changed: \(String(describing: oldValue), privacy: .public) -> \(String(describing: newValue), privacy: .public)")
-            if newValue == .settings || newValue == .help {
-                selectionBeforeSettings = oldValue
-            }
-            // Don't persist settings/help as saved selection
-            if newValue != .settings && newValue != .help {
-                newValue?.save()
-            }
-        }
-        .onKeyPress(.escape) {
-            if selection == .settings || selection == .help {
-                selection = selectionBeforeSettings
-                return .handled
-            }
-            return .ignored
-        }
-        .onAppear {
-            // Intercept Cmd+W at the app level to close tabs instead of the window
-            guard !keyMonitorInstalled else { return }
-            keyMonitorInstalled = true
-            NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "w" {
-                    NotificationCenter.default.post(name: .closeTerminal, object: nil)
-                    return nil // swallow the event
-                }
-                return event
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Split `ContentView.navigationView` into two computed properties (`navigationView` + `navigationViewBase`) to fix Swift type-checker "expression too complex" error at line 340
- Wrapped `sendDesktopNotification` body in `DispatchQueue.main.async` to eliminate main-actor isolation warnings when accessing `NSApp.isActive`

## Test plan
- [x] `./scripts/dev.sh build` succeeds with zero errors and zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)