### PR TITLE
fix: show explicit desktop notifications when app is active

### DIFF
--- a/Sources/Terminal/TerminalApp.swift
+++ b/Sources/Terminal/TerminalApp.swift
@@ -41,10 +41,10 @@ private func handleTerminalAction(
         let notification = action.action.desktop_notification
         let title = notification.title.map { String(cString: $0) } ?? AppConstants.appName
         let body = notification.body.map { String(cString: $0) } ?? ""
-        sendDesktopNotification(title: title, body: body)
+        sendDesktopNotification(title: title, body: body, suppressWhenActive: false)
         return true
     case GHOSTTY_ACTION_RING_BELL:
-        sendDesktopNotification(title: AppConstants.appName, body: "Terminal bell")
+        sendDesktopNotification(title: AppConstants.appName, body: "Terminal bell", suppressWhenActive: true)
         return true
     default:
         return false
@@ -128,9 +128,9 @@ private func writeClipboardText(_ plainText: String) {
     pasteboard.setString(plainText, forType: .string)
 }
 
-private func sendDesktopNotification(title: String, body: String) {
+private func sendDesktopNotification(title: String, body: String, suppressWhenActive: Bool) {
     DispatchQueue.main.async {
-        guard !NSApp.isActive else { return }
+        if suppressWhenActive, NSApp.isActive { return }
         let center = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
         content.title = title


### PR DESCRIPTION
## Summary
- OSC 99 desktop notifications (sent intentionally by programs like Claude) now display even when Factory Floor is the active app
- Bell notifications remain suppressed when the app is focused (you're already looking at the terminal)

## Test plan
- [x] Build succeeds with zero errors and zero warnings
- [ ] Run `echo -e "\e]99;i=1:d=1;Hello\e\\"` in a terminal tab while Factory Floor is focused - notification should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)