### PR TITLE
fix: respawn agent in tmux mode when process exits

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -35,6 +35,7 @@ enum TmuxSession {
         set -g window-size latest
         set -g remain-on-exit on
         set -g remain-on-exit-format ""
+        set-hook -g pane-died 'respawn-pane'
         """
     }
 
@@ -151,7 +152,6 @@ enum TmuxSession {
         let logFile = shellEscape(stderrLogPath)
         let startServer = "\(tmuxPath) -L \(socket) start-server 2>>\(logFile) || true"
         let sourceFile = "\(tmuxPath) -L \(socket) source-file \(conf) 2>>\(logFile)"
-        let clearPaneDiedHook = "\(tmuxPath) -L \(socket) set-hook -gu pane-died 2>>\(logFile) || true"
-        return "\(startServer); \(sourceFile); \(clearPaneDiedHook)"
+        return "\(startServer); \(sourceFile)"
     }
 }

--- a/Tests/TmuxSessionTests.swift
+++ b/Tests/TmuxSessionTests.swift
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for tmux session configuration and command composition.
-// ABOUTME: Verifies the generated config preserves finished panes instead of respawning them.
+// ABOUTME: Verifies the generated config respawns panes on exit for agent persistence.
 
 @testable import FactoryFloor
 import XCTest
@@ -18,9 +18,8 @@ final class TmuxSessionTests: XCTestCase {
         XCTAssertTrue(TmuxSession.configContents.contains("set -g alternate-screen off"))
     }
 
-    func testConfigDoesNotRespawnDeadPanes() {
-        XCTAssertFalse(TmuxSession.configContents.contains("pane-died"))
-        XCTAssertFalse(TmuxSession.configContents.contains("respawn-pane"))
+    func testConfigRespawnsDeadPanes() {
+        XCTAssertTrue(TmuxSession.configContents.contains("set-hook -g pane-died 'respawn-pane'"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit on"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit-format \"\""))
     }
@@ -56,7 +55,7 @@ final class TmuxSessionTests: XCTestCase {
         XCTAssertTrue(command.contains("\\$project"))
     }
 
-    func testWrapCommandClearsStalePaneDiedHookBeforeAttaching() {
+    func testWrapCommandUsesLoginShellAndStartsServer() {
         let command = TmuxSession.wrapCommand(
             tmuxPath: "/opt/homebrew/bin/tmux",
             sessionName: "project/workstream/setup",
@@ -68,7 +67,6 @@ final class TmuxSessionTests: XCTestCase {
         XCTAssertTrue(command.contains("exec sh -c"), "Should use sh for POSIX syntax")
         XCTAssertTrue(command.contains("start-server"))
         XCTAssertTrue(command.contains("source-file"))
-        XCTAssertTrue(command.contains("set-hook -gu pane-died"))
         XCTAssertTrue(command.contains("new-session -A -s"))
         XCTAssertTrue(command.contains("bun run build"))
     }


### PR DESCRIPTION
## Summary
- In tmux mode, Ctrl+D twice froze the terminal because `remain-on-exit on` kept the tmux pane alive but nothing respawned the process
- Ghostty tracks the tmux client process, not the inner claude process, so the app-level respawn callback never fired
- Added `set-hook -g pane-died 'respawn-pane'` to the tmux config so tmux handles the restart itself

## Test plan
- [x] Unit tests updated and passing
- [ ] Enable tmux mode, open a workstream, press Ctrl+D twice in the Coding Agent tab — should respawn instead of freezing
- [ ] Note: cached tmux.conf at `~/Library/Caches/factoryfloor/tmux.conf` will be auto-updated on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)