### PR TITLE
fix: scope tmux respawn hook to agent sessions only

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -35,7 +35,6 @@ enum TmuxSession {
         set -g window-size latest
         set -g remain-on-exit on
         set -g remain-on-exit-format ""
-        set-hook -g pane-died 'respawn-pane'
         """
     }
 
@@ -59,7 +58,7 @@ enum TmuxSession {
     /// Dedicated socket name so we don't interfere with the user's tmux.
     private static let socketName = AppConstants.appID
 
-    static func wrapCommand(tmuxPath: String, sessionName: String, command: String?, environmentVars: [String: String] = [:], shell: String = CommandBuilder.userShell) -> String {
+    static func wrapCommand(tmuxPath: String, sessionName: String, command: String?, environmentVars: [String: String] = [:], respawnOnExit: Bool = false, shell: String = CommandBuilder.userShell) -> String {
         let socket = shellEscape(socketName)
         let conf = shellEscape(configPath)
         let escaped = shellEscape(sessionName)
@@ -74,6 +73,9 @@ enum TmuxSession {
         if let command {
             // Command is already shell-quoted by the caller (runScriptCommand/scriptCommand)
             tmuxCmd += " \(command)"
+        }
+        if respawnOnExit {
+            tmuxCmd += " \\; set-hook pane-died 'respawn-pane'"
         }
 
         // Use login shell for proper PATH, with inner sh for POSIX syntax.

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -272,7 +272,7 @@ struct TerminalContainerView: View {
         var intermediates = [resume.command, fresh.command, cmd]
         if useTmux, let tmuxPath = appEnv.toolStatus.tmux.path {
             let session = TmuxSession.sessionName(project: projectName, workstream: workstreamName, role: "agent")
-            finalCommand = TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: cmd, environmentVars: envVars)
+            finalCommand = TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: cmd, environmentVars: envVars, respawnOnExit: true)
             intermediates.append(finalCommand)
         } else {
             finalCommand = cmd

--- a/Tests/TmuxSessionTests.swift
+++ b/Tests/TmuxSessionTests.swift
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for tmux session configuration and command composition.
-// ABOUTME: Verifies the generated config respawns panes on exit for agent persistence.
+// ABOUTME: Verifies respawn behavior is scoped to agent sessions, not global.
 
 @testable import FactoryFloor
 import XCTest
@@ -18,10 +18,31 @@ final class TmuxSessionTests: XCTestCase {
         XCTAssertTrue(TmuxSession.configContents.contains("set -g alternate-screen off"))
     }
 
-    func testConfigRespawnsDeadPanes() {
-        XCTAssertTrue(TmuxSession.configContents.contains("set-hook -g pane-died 'respawn-pane'"))
+    func testConfigDoesNotGloballyRespawnDeadPanes() {
+        XCTAssertFalse(TmuxSession.configContents.contains("pane-died"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit on"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit-format \"\""))
+    }
+
+    func testRespawnOnExitAddsSessionLevelHook() {
+        let command = TmuxSession.wrapCommand(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            sessionName: "proj/ws/agent",
+            command: "claude",
+            respawnOnExit: true,
+            shell: "/bin/zsh"
+        )
+        XCTAssertTrue(command.contains("set-hook pane-died"))
+    }
+
+    func testDefaultDoesNotRespawn() {
+        let command = TmuxSession.wrapCommand(
+            tmuxPath: "/opt/homebrew/bin/tmux",
+            sessionName: "proj/ws/setup",
+            command: "setup.sh",
+            shell: "/bin/zsh"
+        )
+        XCTAssertFalse(command.contains("pane-died"))
     }
 
     func testWrapCommandQuotesEnvVarValuesWithSpaces() {


### PR DESCRIPTION
## Summary
- The global `pane-died` hook from #267 respawned all panes on the socket, causing setup/run scripts to restart in a loop after finishing
- Moved the respawn hook from the global tmux config to a session-level hook, applied only to agent sessions via a new `respawnOnExit` parameter on `wrapCommand`

## Test plan
- [x] All 116 existing tests pass
- [x] New tests verify respawn hook is present for agent sessions and absent by default
- [ ] Manual: enable tmux mode, create a workstream with a setup script, confirm it runs once and stops
- [ ] Manual: confirm Ctrl+D on the agent tab still respawns the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)