### PR TITLE
fix: enable desktop notifications with foreground presentation

### DIFF
--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -4,6 +4,7 @@
 import Sentry
 import Sparkle
 import SwiftUI
+import UserNotifications
 
 extension Notification.Name {
     static let openDirectory = Notification.Name("factoryfloor.openDirectory")
@@ -20,7 +21,19 @@ extension Notification.Name {
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
+    func applicationDidFinishLaunching(_: Notification) {
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        willPresent _: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
     func applicationWillTerminate(_: Notification) {
         let tmuxPath = ToolStatus.detect().tmux.path
         if let tmuxPath {


### PR DESCRIPTION
## Summary
- Added `UNUserNotificationCenterDelegate` conformance to `AppDelegate` so macOS shows notification banners even when the app is in the foreground
- Sets the delegate in `applicationDidFinishLaunching` and returns `.banner, .sound` from `willPresent`
- No compilation warnings found (the linker search path warning for GhosttyKit.xcframework is expected)

## Test plan
- [ ] Trigger an OSC 9 notification from a terminal (e.g. `printf '\e]9;Hello\e\\'`) and verify the banner appears
- [ ] Verify notifications appear both when the app is focused and when it's in the background
- [ ] Verify the terminal bell (`printf '\a'`) still shows a notification only when the app is not active

🤖 Generated with [Claude Code](https://claude.com/claude-code)