### PR TITLE
fix: prevent user tmux config from leaking into sessions

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -152,7 +152,7 @@ enum TmuxSession {
         let socket = shellEscape(socketName)
         let conf = shellEscape(configPath)
         let logFile = shellEscape(stderrLogPath)
-        let startServer = "\(tmuxPath) -L \(socket) start-server 2>>\(logFile) || true"
+        let startServer = "\(tmuxPath) -L \(socket) -f \(conf) start-server 2>>\(logFile) || true"
         let sourceFile = "\(tmuxPath) -L \(socket) source-file \(conf) 2>>\(logFile)"
         return "\(startServer); \(sourceFile)"
     }


### PR DESCRIPTION
## Summary
- The `start-server` command was missing `-f conf`, so tmux loaded `~/.tmux.conf` before our minimal config was sourced
- User settings like `pane-border-status` leaked through, showing an unwanted `── 0 hostname ───` line above each pane
- Added `-f` flag to `start-server` so the server starts exclusively with the factoryfloor config

## Test plan
- [ ] Enable tmux mode, open a workstream, verify no pane border status line appears
- [ ] Verify agent respawn still works (Ctrl+D twice)
- [ ] Verify setup/run scripts still execute and don't respawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)