### PR TITLE
fix: revert worktree-create hook to symlink only xcframework

### DIFF
--- a/.hooks/worktree-create.sh
+++ b/.hooks/worktree-create.sh
@@ -6,13 +6,12 @@ set -euo pipefail
 : "${WORKTREE_DIR:?WORKTREE_DIR must be set}"
 : "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR must be set}"
 
-# Ghostty submodule (headers + xcframework, built with zig, not in git)
-GHOSTTY_SRC="$CLAUDE_PROJECT_DIR/ghostty"
-GHOSTTY_DST="$WORKTREE_DIR/ghostty"
+# Ghostty xcframework (built with zig, not in git)
+XCFW_SRC="$CLAUDE_PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework"
+XCFW_DST="$WORKTREE_DIR/ghostty/macos/GhosttyKit.xcframework"
 
-if [ -d "$GHOSTTY_SRC" ] && [ ! -e "$GHOSTTY_DST/include" ]; then
-    rm -rf "$GHOSTTY_DST"
-    ln -sfn "$GHOSTTY_SRC" "$GHOSTTY_DST"
+if [ -d "$XCFW_SRC" ] && [ ! -e "$XCFW_DST" ]; then
+    ln -sfn "$XCFW_SRC" "$XCFW_DST"
 fi
 
 # Build so SourceKit can resolve symbols across files in the worktree.


### PR DESCRIPTION
## Summary
- Reverts the worktree-create hook change from #264 that replaced the targeted xcframework symlink with a full ghostty directory symlink
- The full-directory symlink broke builds in new worktrees because the guard condition checked for `include/` (already present in the submodule checkout), so the xcframework never got symlinked

## Test plan
- [ ] Create a new worktree with `claude -w` and verify it builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)