### PR TITLE
fix: dispatch notification authorization handler to main thread

### DIFF
--- a/Sources/Terminal/TerminalApp.swift
+++ b/Sources/Terminal/TerminalApp.swift
@@ -195,10 +195,12 @@ final class TerminalApp {
         UNUserNotificationCenter.current().requestAuthorization(
             options: [.alert, .sound]
         ) { granted, error in
-            if let error {
-                logger.warning("Notification permission error: \(error.localizedDescription)")
-            } else if !granted {
-                logger.info("Notification permission denied by user")
+            DispatchQueue.main.async {
+                if let error {
+                    logger.warning("Notification permission error: \(error.localizedDescription)")
+                } else if !granted {
+                    logger.info("Notification permission denied by user")
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Wraps the `UNUserNotificationCenter.requestAuthorization` completion handler in `DispatchQueue.main.async`
- macOS 26 enforces main-thread-only dispatch for UserNotifications callbacks, causing a `libdispatch` assertion crash (`EXC_BREAKPOINT`) on launch

Closes #274

## Test plan
- [ ] Launch Factory Floor on macOS 26 and confirm no crash
- [ ] Verify notification permissions prompt still appears
- [ ] Confirm no regression on macOS 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)