### PR TITLE
fix: move notification auth to applicationDidFinishLaunching

### DIFF
--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -1,10 +1,13 @@
 // ABOUTME: Main application entry point.
 // ABOUTME: Initializes the ghostty terminal engine and presents the main window.
 
+import os
 import Sentry
 import Sparkle
 import SwiftUI
 import UserNotifications
+
+private let logger = Logger(subsystem: "factoryfloor", category: "app")
 
 extension Notification.Name {
     static let openDirectory = Notification.Name("factoryfloor.openDirectory")
@@ -23,7 +26,15 @@ extension Notification.Name {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     func applicationDidFinishLaunching(_: Notification) {
-        UNUserNotificationCenter.current().delegate = self
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                logger.warning("Notification permission error: \(error.localizedDescription)")
+            } else if !granted {
+                logger.info("Notification permission denied by user")
+            }
+        }
     }
 
     nonisolated func userNotificationCenter(

--- a/Sources/Terminal/TerminalApp.swift
+++ b/Sources/Terminal/TerminalApp.swift
@@ -192,18 +192,6 @@ final class TerminalApp {
             }
         }
 
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: [.alert, .sound]
-        ) { granted, error in
-            DispatchQueue.main.async {
-                if let error {
-                    logger.warning("Notification permission error: \(error.localizedDescription)")
-                } else if !granted {
-                    logger.info("Notification permission denied by user")
-                }
-            }
-        }
-
         NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,


### PR DESCRIPTION
## Summary

- Moved `requestAuthorization` from `TerminalApp.init()` (lazy static singleton) to `AppDelegate.applicationDidFinishLaunching`, where the app lifecycle is fully initialized
- On macOS 26, calling `UNUserNotificationCenter.requestAuthorization` before the app is fully launched triggers a libdispatch main-thread assertion crash (`EXC_BREAKPOINT` at `libdispatch.dylib`)
- The previous fix (#275) wrapped the completion handler in `DispatchQueue.main.async`, but the issue was the **timing** of the call, not the thread of the callback

Closes #274

## Test plan

- [ ] Build a signed release and install on macOS 26
- [ ] Verify app launches without crashing
- [ ] Verify notification permissions prompt appears (or is remembered from prior grant)
- [ ] Verify desktop notifications work (terminal bell, OSC 9/99)

> Note: cannot verify locally because `./scripts/dev.sh release` uses ad-hoc signing which fails to load team-signed Sparkle. Debug build confirms the app starts cleanly with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)