### PR TITLE
fix: use local entitlements to bypass library validation in dev release builds

### DIFF
--- a/Resources/ff2-local.entitlements
+++ b/Resources/ff2-local.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -60,9 +60,11 @@ case "${1:-build}" in
       CODE_SIGN_STYLE=Manual \
       ENABLE_HARDENED_RUNTIME=YES \
       CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+      CODE_SIGN_ENTITLEMENTS=Resources/ff2-local.entitlements \
       OTHER_CODE_SIGN_FLAGS="--options=runtime" \
       build
-    echo "==> Release build at: $RELEASE_DIR/Build/Products/Release/Factory Floor.app"
+    APP_BUNDLE="$RELEASE_DIR/Build/Products/Release/Factory Floor.app"
+    echo "==> Release build at: $APP_BUNDLE"
     if [ "${2:-}" = "--run" ]; then
       pkill -xf ".*/Contents/MacOS/Factory Floor" 2>/dev/null || true
       sleep 0.5


### PR DESCRIPTION
## Summary
- Adds `Resources/ff2-local.entitlements` with `com.apple.security.cs.disable-library-validation` for local release builds
- Updates `dev.sh release` to use the local entitlements file instead of production entitlements
- Production release builds (`scripts/release.sh`) are unaffected and keep strict library validation

Closes #279

## Test plan
- [x] `./scripts/dev.sh release --run` launches successfully
- [ ] `./scripts/release.sh` still produces a valid signed/notarized build

🤖 Generated with [Claude Code](https://claude.com/claude-code)