### PR TITLE
fix: bundle ghostty terminfo and shell integration in app resources

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -94,6 +94,12 @@ targets:
         buildPhase: resources
       - path: Resources/notification.wav
         buildPhase: resources
+      - path: ghostty/zig-out/share/terminfo
+        type: folder
+        buildPhase: resources
+      - path: ghostty/zig-out/share/ghostty
+        type: folder
+        buildPhase: resources
     settings:
       base:
         PRODUCT_MODULE_NAME: FactoryFloor


### PR DESCRIPTION
## Summary
- The app launched without a window because Ghostty's terminfo sentinel was missing from the app bundle, causing resource discovery to fail and the terminal component to crash on init
- Adds `ghostty/zig-out/share/terminfo` and `ghostty/zig-out/share/ghostty` as folder references in `project.yml` so they are copied into `Contents/Resources/`
- These were never bundled before; the app only worked previously when run from the build tree where Ghostty could find them by climbing the directory tree

## Test plan
- [x] Debug build succeeds
- [x] `Contents/Resources/terminfo/78/xterm-ghostty` present in bundle
- [x] `Contents/Resources/ghostty/shell-integration/` present in bundle
- [x] App launches with window visible, no terminfo warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)