### PR TITLE
fix(ci): cache ghostty share dirs needed by xcodegen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,10 @@ jobs:
         id: ghostty-cache
         uses: actions/cache@v5
         with:
-          path: ghostty/macos/GhosttyKit.xcframework
-          key: ghostty-xcframework-${{ hashFiles('ghostty/.git') }}
+          path: |
+            ghostty/macos/GhosttyKit.xcframework
+            ghostty/zig-out/share
+          key: ghostty-build-${{ hashFiles('ghostty/.git') }}
 
       - name: Build Ghostty xcframework
         if: steps.ghostty-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- The release workflow cache only stored the xcframework, not `ghostty/zig-out/share/`. After bd4ea71 added those dirs to `project.yml`, xcodegen fails validation on cache hits because the share directories are missing.
- Added `ghostty/zig-out/share` to the cache path and renamed the cache key to bust the stale entry.

## Test plan
- [ ] Trigger a release and verify the "Generate Xcode project" step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)