### PR TITLE
fix: handle notification authorization on main thread

### DIFF
--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -25,14 +25,45 @@ extension Notification.Name {
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
+    enum NotificationAuthorizationLogLevel {
+        case info
+        case warning
+    }
+
     func applicationDidFinishLaunching(_: Notification) {
         let center = UNUserNotificationCenter.current()
         center.delegate = self
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            Self.handleNotificationAuthorizationResult(granted: granted, error: error)
+        }
+    }
+
+    nonisolated static func handleNotificationAuthorizationResult(
+        granted: Bool,
+        error: (any Error)?,
+        log: @escaping @Sendable (String, NotificationAuthorizationLogLevel) -> Void = { message, level in
+            switch level {
+            case .info:
+                logger.info("\(message, privacy: .public)")
+            case .warning:
+                logger.warning("\(message, privacy: .public)")
+            }
+        }
+    ) {
+        if Thread.isMainThread {
             if let error {
-                logger.warning("Notification permission error: \(error.localizedDescription)")
+                log("Notification permission error: \(error.localizedDescription)", .warning)
             } else if !granted {
-                logger.info("Notification permission denied by user")
+                log("Notification permission denied by user", .info)
+            }
+            return
+        }
+
+        Task { @MainActor in
+            if let error {
+                log("Notification permission error: \(error.localizedDescription)", .warning)
+            } else if !granted {
+                log("Notification permission denied by user", .info)
             }
         }
     }

--- a/Tests/AppDelegateTests.swift
+++ b/Tests/AppDelegateTests.swift
@@ -1,0 +1,20 @@
+// ABOUTME: Tests for AppDelegate startup behaviors that interact with system callbacks.
+// ABOUTME: Verifies notification authorization results are handled on the main thread.
+
+@testable import FactoryFloor
+import XCTest
+
+final class AppDelegateTests: XCTestCase {
+    func testNotificationAuthorizationResultIsHandledOnMainThread() {
+        let handledOnMainThread = expectation(description: "notification authorization handled on main thread")
+
+        DispatchQueue.global().async(group: nil, qos: .default, flags: []) {
+            AppDelegate.handleNotificationAuthorizationResult(granted: false, error: nil) { _, _ in
+                XCTAssertTrue(Thread.isMainThread)
+                handledOnMainThread.fulfill()
+            }
+        }
+
+        wait(for: [handledOnMainThread], timeout: 1)
+    }
+}


### PR DESCRIPTION
## Summary
- route notification authorization completion handling through a dedicated AppDelegate helper
- ensure denied/error handling runs on the main actor before logging
- add a regression test for off-main-thread authorization callbacks

## Testing
- ./scripts/dev.sh test