### PR TITLE
fix: remove sendable requirement from notification request protocol

### DIFF
--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -9,7 +9,7 @@ import UserNotifications
 
 private let logger = Logger(subsystem: "factoryfloor", category: "app")
 
-protocol NotificationAuthorizationRequesting: Sendable {
+protocol NotificationAuthorizationRequesting {
     func requestAuthorization(
         options: UNAuthorizationOptions,
         completionHandler: @escaping @Sendable (Bool, (any Error)?) -> Void


### PR DESCRIPTION
## Summary
Fix the 0.1.59 release build failure by removing the retroactive  requirement from .

## Why
The GitHub Actions release build for 0.1.59 failed in  with:


That blocked the fixed notification startup code from shipping.

## Verification
- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project FactoryFloor.xcodeproj -scheme FactoryFloorTests -configuration Debug "-only-testing:FactoryFloorTests/AppDelegateTests" test

Resolve Package Graph


Resolved source packages:
  Sentry: https://github.com/getsentry/sentry-cocoa @ 9.7.0
  cmark-gfm: https://github.com/swiftlang/swift-cmark.git @ 0.7.1
  Sparkle: https://github.com/sparkle-project/Sparkle @ 2.9.0

ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (10 targets)
    Target 'FactoryFloorTests' in project 'FactoryFloor'
        ➜ Explicit dependency on target 'FactoryFloor' in project 'FactoryFloor'
    Target 'FactoryFloor' in project 'FactoryFloor'
        ➜ Explicit dependency on target 'FFRun' in project 'FactoryFloor'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'Sentry' in project 'Sentry'
        ➜ Explicit dependency on target 'Sparkle' in project 'Sparkle'
    Target 'Sparkle' in project 'Sparkle' (no dependencies)
    Target 'Sentry' in project 'Sentry'
        ➜ Explicit dependency on target 'SentryCppHelper' in project 'Sentry'
    Target 'SentryCppHelper' in project 'Sentry' (no dependencies)
    Target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
    Target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
    Target 'cmark-gfm' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
    Target 'cmark-gfm' in project 'cmark-gfm' (no dependencies)
    Target 'FFRun' in project 'FactoryFloor' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

Build description signature: 9f579fa981c7643b088e5df9913b985f
Build description path: /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/XCBuildData/9f579fa981c7643b088e5df9913b985f.xcbuilddata
ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /Users/dpoblador/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
    cd /Users/dpoblador/repos/factoryfloor/FactoryFloor.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /Users/dpoblador/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache

CopySwiftLibs /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-swiftStdLibTool --copy --verbose --sign - --scan-executable /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/MacOS/Factory\ Floor\ Debug.debug.dylib --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Frameworks --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Library/SystemExtensions --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/FactoryFloor.build/Debug/FactoryFloor.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span

ProcessInfoPlistFile /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Info.plist /Users/dpoblador/repos/factoryfloor/FactoryFloor/Info.plist (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-infoPlistUtility /Users/dpoblador/repos/factoryfloor/FactoryFloor/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/FactoryFloor.build/Debug/FactoryFloor.build/assetcatalog_generated_info.plist -scanforprivacyfile /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Frameworks/Sentry.framework -scanforprivacyfile /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Frameworks/Sparkle.framework -o /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/Info.plist

ProcessInfoPlistFile /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/Info.plist /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/FactoryFloor.build/Debug/FactoryFloorTests.build/empty-FactoryFloorTests.plist (in target 'FactoryFloorTests' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-infoPlistUtility /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/FactoryFloor.build/Debug/FactoryFloorTests.build/empty-FactoryFloorTests.plist -producttype com.apple.product-type.bundle.unit-test -expandbuildsettings -platform macosx -o /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/Info.plist

CopySwiftLibs /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest (in target 'FactoryFloorTests' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-swiftStdLibTool --copy --verbose --sign - --scan-executable /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/MacOS/FactoryFloorTests --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/Frameworks --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/PlugIns --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/Library/SystemExtensions --scan-folder /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/PlugIns/FactoryFloorTests.xctest/Contents/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/FactoryFloor.build/Debug/FactoryFloorTests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span

CodeSign /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/MacOS/Factory\ Floor\ Debug.debug.dylib (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    
    Signing Identity:     "Sign to Run Locally"
    
    /usr/bin/codesign --force --sign - --timestamp\=none --generate-entitlement-der /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/MacOS/Factory\ Floor\ Debug.debug.dylib
/Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory Floor Debug.app/Contents/MacOS/Factory Floor Debug.debug.dylib: replacing existing signature

CodeSign /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/MacOS/__preview.dylib (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    
    Signing Identity:     "Sign to Run Locally"
    
    /usr/bin/codesign --force --sign - --timestamp\=none --generate-entitlement-der /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app/Contents/MacOS/__preview.dylib
/Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory Floor Debug.app/Contents/MacOS/__preview.dylib: replacing existing signature

CodeSign /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    
    Signing Identity:     "Sign to Run Locally"
    
    /usr/bin/codesign --force --sign - --entitlements /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Intermediates.noindex/FactoryFloor.build/Debug/FactoryFloor.build/Factory\ Floor\ Debug.app.xcent --timestamp\=none --generate-entitlement-der /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app
/Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory Floor Debug.app: replacing existing signature

Validate /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-validationUtility /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app -no-validate-extension -infoplist-subpath Contents/Info.plist

RegisterWithLaunchServices /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory\ Floor\ Debug.app

2026-04-01 03:58:33.258689+0200 Factory Floor Debug[46716:2227812] [default] ghostty version=1.3.2-main+e75f8956c
2026-04-01 03:58:33.258767+0200 Factory Floor Debug[46716:2227812] [default] ghostty build optimize=ReleaseFast
2026-04-01 03:58:33.258794+0200 Factory Floor Debug[46716:2227812] [default] runtime=.none
2026-04-01 03:58:33.258836+0200 Factory Floor Debug[46716:2227812] [default] font_backend=.coretext
2026-04-01 03:58:33.258875+0200 Factory Floor Debug[46716:2227812] [default] renderer=renderer.generic.Renderer(renderer.Metal)
2026-04-01 03:58:33.258935+0200 Factory Floor Debug[46716:2227812] [default] libxev default backend=kqueue
2026-04-01 03:58:33.259063+0200 Factory Floor Debug[46716:2227812] [os_locale] os_locale: detected system locale=en_ES.UTF-8
2026-04-01 03:58:33.259588+0200 Factory Floor Debug[46716:2227812] [os_locale] os_locale: setlocale after unset lang result=C
2026-04-01 03:58:33.259616+0200 Factory Floor Debug[46716:2227812] [os_locale] os_locale: setlocale failed with LANG and system default. Falling back to en_US.UTF-8
2026-04-01 03:58:33.259703+0200 Factory Floor Debug[46716:2227812] [os_locale] os_locale: setlocale default result=en_US.UTF-8
2026-04-01 03:58:33.260054+0200 Factory Floor Debug[46716:2227856] [sentry] sentry: sentry envelope does not contain crash, discarding
2026-04-01 03:58:33.320257+0200 Factory Floor Debug[46716:2227812] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to /var/folders/3x/d3qtx8nj4tgc87ycmjjmk5zr0000gn/T/com.alltuner.factoryfloor.debug.savedState
2026-04-01 03:58:33.524294+0200 Factory Floor Debug[46716:2227812] [default] reading configuration file path=/Users/dpoblador/.config/ghostty/config
2026-04-01 03:58:33.524790+0200 Factory Floor Debug[46716:2227812] [config] config: default shell src=passwd value=/bin/zsh
2026-04-01 03:58:33.524803+0200 Factory Floor Debug[46716:2227812] [config] config: default working directory src=passwd value=/Users/dpoblador
2026-04-01 03:58:33.529958+0200 Factory Floor Debug[46716:2227812] [font_shared_grid_set] font_shared_grid_set: font regular: JetBrainsMono NF Regular
2026-04-01 03:58:33.530716+0200 Factory Floor Debug[46716:2227812] [font_shared_grid_set] font_shared_grid_set: font bold: JetBrainsMono NF Bold
2026-04-01 03:58:33.531823+0200 Factory Floor Debug[46716:2227812] [font_shared_grid_set] font_shared_grid_set: font italic: JetBrainsMono NF Italic
2026-04-01 03:58:33.532732+0200 Factory Floor Debug[46716:2227812] [font_shared_grid_set] font_shared_grid_set: font bold_italic: JetBrainsMono NF Bold Italic
2026-04-01 03:58:33.538018+0200 Factory Floor Debug[46716:2227812] [io_exec] io_exec: found Ghostty resources dir: /Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Build/Products/Debug/Factory Floor Debug.app/Contents/Resources/ghostty
2026-04-01 03:58:33.538146+0200 Factory Floor Debug[46716:2227812] [io_exec] io_exec: shell integration automatically injected shell=.zsh
2026-04-01 03:58:33.541360+0200 Factory Floor Debug[46716:2227887] [io_exec] io_exec: started subcommand path=/usr/bin/login pid=46723
Test Suite 'Selected tests' started at 2026-04-01 03:58:33.667.
Test Suite 'FactoryFloorTests.xctest' started at 2026-04-01 03:58:33.668.
Test Suite 'AppDelegateTests' started at 2026-04-01 03:58:33.668.
Test Case '-[FactoryFloorTests.AppDelegateTests testNotificationAuthorizationRequestHandlesBackgroundCallbackOnMainThread]' started.
Test Case '-[FactoryFloorTests.AppDelegateTests testNotificationAuthorizationRequestHandlesBackgroundCallbackOnMainThread]' passed (0.007 seconds).
Test Case '-[FactoryFloorTests.AppDelegateTests testNotificationAuthorizationResultIsHandledOnMainThread]' started.
Test Case '-[FactoryFloorTests.AppDelegateTests testNotificationAuthorizationResultIsHandledOnMainThread]' passed (0.001 seconds).
Test Suite 'AppDelegateTests' passed at 2026-04-01 03:58:33.676.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.008 (0.009) seconds
Test Suite 'FactoryFloorTests.xctest' passed at 2026-04-01 03:58:33.677.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.008 (0.009) seconds
Test Suite 'Selected tests' passed at 2026-04-01 03:58:33.677.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.008 (0.010) seconds

Test session results, code coverage, and logs:
	/Users/dpoblador/Library/Developer/Xcode/DerivedData/FactoryFloor-cppkhnrkpvraaqfwcfweoguwnchn/Logs/Test/Test-FactoryFloorTests-2026.04.01_03-58-30-+0200.xcresult

** TEST SUCCEEDED **

Testing started
- ⚙️  Generating plists...
⚙️  Generating project...
⚙️  Writing project...
Created project at /Users/dpoblador/repos/factoryfloor/FactoryFloor.xcodeproj
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project FactoryFloor.xcodeproj -scheme FactoryFloor -configuration Release -derivedDataPath build/release-local/derived -clonedSourcePackagesDirPath /Users/dpoblador/Library/Caches/factoryfloor/spm CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual ENABLE_HARDENED_RUNTIME=YES CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO CODE_SIGN_ENTITLEMENTS=Resources/ff2-local.entitlements OTHER_CODE_SIGN_FLAGS=--options=runtime build

Build settings from command line:
    CODE_SIGN_ENTITLEMENTS = Resources/ff2-local.entitlements
    CODE_SIGN_IDENTITY = -
    CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO
    CODE_SIGN_STYLE = Manual
    ENABLE_HARDENED_RUNTIME = YES
    OTHER_CODE_SIGN_FLAGS = --options=runtime

Resolve Package Graph


Resolved source packages:
  Sentry: https://github.com/getsentry/sentry-cocoa @ 9.7.0
  Sparkle: https://github.com/sparkle-project/Sparkle @ 2.9.0
  cmark-gfm: https://github.com/swiftlang/swift-cmark @ 0.7.1

note: Using codesigning identity override: -
ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (9 targets)
    Target 'FactoryFloor' in project 'FactoryFloor'
        ➜ Explicit dependency on target 'FFRun' in project 'FactoryFloor'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'Sentry' in project 'Sentry'
        ➜ Explicit dependency on target 'Sparkle' in project 'Sparkle'
    Target 'Sparkle' in project 'Sparkle' (no dependencies)
    Target 'Sentry' in project 'Sentry'
        ➜ Explicit dependency on target 'SentryCppHelper' in project 'Sentry'
    Target 'SentryCppHelper' in project 'Sentry' (no dependencies)
    Target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
    Target 'cmark-gfm-extensions' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
    Target 'cmark-gfm' in project 'cmark-gfm'
        ➜ Explicit dependency on target 'cmark-gfm' in project 'cmark-gfm'
    Target 'cmark-gfm' in project 'cmark-gfm' (no dependencies)
    Target 'FFRun' in project 'FactoryFloor' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

Build description signature: 79a01e99f8bdfa6ce80709d9bc16b141
Build description path: /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Intermediates.noindex/XCBuildData/79a01e99f8bdfa6ce80709d9bc16b141.xcbuilddata
ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /Users/dpoblador/repos/factoryfloor/build/release-local/derived/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
    cd /Users/dpoblador/repos/factoryfloor/FactoryFloor.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /Users/dpoblador/repos/factoryfloor/build/release-local/derived/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache

CopySwiftLibs /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-swiftStdLibTool --copy --verbose --sign - --Xcodesign --options\=runtime --scan-executable /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/MacOS/Factory\ Floor --scan-folder /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Frameworks --scan-folder /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/PlugIns --scan-folder /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Library/SystemExtensions --scan-folder /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Intermediates.noindex/FactoryFloor.build/Release/FactoryFloor.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span

ProcessInfoPlistFile /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Info.plist /Users/dpoblador/repos/factoryfloor/FactoryFloor/Info.plist (in target 'FactoryFloor' from project 'FactoryFloor')
    cd /Users/dpoblador/repos/factoryfloor
    builtin-infoPlistUtility /Users/dpoblador/repos/factoryfloor/FactoryFloor/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Intermediates.noindex/FactoryFloor.build/Release/FactoryFloor.build/assetcatalog_generated_info.plist -scanforprivacyfile /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Frameworks/Sentry.framework -scanforprivacyfile /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Frameworks/Sparkle.framework -o /Users/dpoblador/repos/factoryfloor/build/release-local/derived/Build/Products/Release/Factory\ Floor.app/Contents/Info.plist

** BUILD SUCCEEDED **

==> Release build at: build/release-local/derived/Build/Products/Release/Factory Floor.app
