### PR TITLE
fix: check Ghostty resources exist before building

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -12,9 +12,19 @@ BUILD_DIR="build/debug/derived"
 APP_PATH="$BUILD_DIR/Build/Products/Debug/$APP_NAME.app"
 SPM_CACHE="$HOME/Library/Caches/factoryfloor/spm"
 BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+GHOSTTY_RESOURCES="ghostty/zig-out/share"
+
+ensure_ghostty_resources() {
+  if [ ! -d "$GHOSTTY_RESOURCES/terminfo" ] || [ ! -d "$GHOSTTY_RESOURCES/ghostty" ]; then
+    echo "error: Ghostty resources not found at $GHOSTTY_RESOURCES/"
+    echo "       Build the xcframework first: cd ghostty && zig build"
+    exit 1
+  fi
+}
 
 case "${1:-build}" in
   build)
+    ensure_ghostty_resources
     xcodegen generate
     xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Debug \
       -derivedDataPath "$BUILD_DIR" -clonedSourcePackagesDirPath "$SPM_CACHE" \
@@ -33,6 +43,7 @@ case "${1:-build}" in
     ;;
   br)
     shift 2>/dev/null || true
+    ensure_ghostty_resources
     xcodegen generate
     xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Debug \
       -derivedDataPath "$BUILD_DIR" -clonedSourcePackagesDirPath "$SPM_CACHE" \
@@ -47,12 +58,14 @@ case "${1:-build}" in
     fi
     ;;
   test)
+    ensure_ghostty_resources
     xcodegen generate
     xcodebuild -project "$PROJECT" -scheme "$TEST_SCHEME" -configuration Debug \
       -derivedDataPath "$BUILD_DIR" -clonedSourcePackagesDirPath "$SPM_CACHE" test
     ;;
   release)
     RELEASE_DIR="build/release-local/derived"
+    ensure_ghostty_resources
     xcodegen generate
     xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration Release \
       -derivedDataPath "$RELEASE_DIR" -clonedSourcePackagesDirPath "$SPM_CACHE" \


### PR DESCRIPTION
## Summary
- Adds `ensure_ghostty_resources` guard to `dev.sh` that checks `ghostty/zig-out/share/terminfo` and `ghostty/zig-out/share/ghostty` exist before running any build command
- Applies to `build`, `br`, `test`, and `release` subcommands
- Errors with a clear message pointing to `cd ghostty && zig build`

Closes #284

## Test plan
- [ ] Run `dev.sh build` with Ghostty resources present (should work as before)
- [ ] Remove/rename `ghostty/zig-out/share/terminfo`, run `dev.sh build` (should error with helpful message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)