### PR TITLE
fix: cache isGitRepo and port state to avoid main-thread I/O in sidebar

### DIFF
--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -1,8 +1,8 @@
 // ABOUTME: Detects installed tools, apps, and git repo status.
 // ABOUTME: Shared across the app as an environment object with async background updates.
 
-import SwiftUI
 import OSLog
+import SwiftUI
 
 private let logger = Logger(subsystem: "factoryfloor", category: "environment")
 
@@ -17,11 +17,17 @@ final class AppEnvironment: ObservableObject {
     @Published private var repoInfoCache: [String: GitRepoInfo] = [:]
     private var repoInfoTimestamps: [String: Date] = [:]
 
-    // Worktree path validity cache
+    /// Worktree path validity cache
     @Published private var pathValidityCache: [String: Bool] = [:]
 
-    // Branch name cache per worktree path
+    /// Branch name cache per worktree path
     @Published private var branchNameCache: [String: String] = [:]
+
+    /// Git repo detection cache per project directory
+    @Published private var gitRepoCache: [String: Bool] = [:]
+
+    /// Active port cache per workstream ID
+    @Published private var activePortCache: Set<UUID> = []
 
     // GitHub info cache
     @Published private var githubRepoCache: [String: GitHubRepoInfo] = [:]
@@ -52,7 +58,8 @@ final class AppEnvironment: ObservableObject {
     func refreshRepoInfo(for directory: String) {
         // Skip if refreshed within the last 5 seconds
         if let lastRefresh = repoInfoTimestamps[directory],
-           Date().timeIntervalSince(lastRefresh) < 5 {
+           Date().timeIntervalSince(lastRefresh) < 5
+        {
             return
         }
         repoInfoTimestamps[directory] = Date()
@@ -74,7 +81,8 @@ final class AppEnvironment: ObservableObject {
             let minInterval: TimeInterval = age < 300 ? 10 : 60 // 10s for recent, 60s for stale
 
             if let lastRefresh = repoInfoTimestamps[project.directory],
-               now.timeIntervalSince(lastRefresh) < minInterval {
+               now.timeIntervalSince(lastRefresh) < minInterval
+            {
                 continue
             }
 
@@ -101,6 +109,14 @@ final class AppEnvironment: ObservableObject {
         return branchNameCache[path]
     }
 
+    func isGitRepo(_ directory: String) -> Bool {
+        gitRepoCache[directory] ?? false
+    }
+
+    func hasActivePort(_ workstreamID: UUID) -> Bool {
+        activePortCache.contains(workstreamID)
+    }
+
     /// Returns IDs of projects whose directories no longer exist.
     @Published var missingProjectIDs: Set<UUID> = []
 
@@ -108,6 +124,8 @@ final class AppEnvironment: ObservableObject {
         Task.detached {
             var results: [String: Bool] = [:]
             var missing: Set<UUID> = []
+            var gitRepoResults: [String: Bool] = [:]
+            var portResults: Set<UUID> = []
 
             // Collect valid worktree paths that need git info
             var validPaths: [String] = []
@@ -120,7 +138,13 @@ final class AppEnvironment: ObservableObject {
                     missing.insert(project.id)
                 }
 
+                gitRepoResults[project.directory] = GitOperations.isGitRepo(at: project.directory)
+
                 for ws in project.workstreams {
+                    if RunStateStore.loadValidated(for: ws.id)?.detectedPorts.isEmpty == false {
+                        portResults.insert(ws.id)
+                    }
+
                     guard let path = ws.worktreePath else { continue }
                     var wsIsDir: ObjCBool = false
                     let valid = FileManager.default.fileExists(atPath: path, isDirectory: &wsIsDir) && wsIsDir.boolValue
@@ -154,6 +178,8 @@ final class AppEnvironment: ObservableObject {
                 self.pathValidityCache.merge(results) { _, new in new }
                 self.branchNameCache.merge(branches) { _, new in new }
                 self.missingProjectIDs = missing
+                self.gitRepoCache.merge(gitRepoResults) { _, new in new }
+                self.activePortCache = portResults
             }
         }
     }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -85,7 +85,7 @@ struct ProjectSidebar: View {
                         }
                     }
                 } : nil,
-                isGitRepo: GitOperations.isGitRepo(at: project.directory),
+                isGitRepo: appEnv.isGitRepo(project.directory),
                 onAdd: { logger.warning("[FF] onAdd button tapped for project \(project.name, privacy: .public)"); addWorkstream(for: project.id) },
                 onAddWithPermissions: { addWorkstream(for: project.id, bypassPermissions: true) },
                 onAddWithoutPermissions: { addWorkstream(for: project.id, bypassPermissions: false) },
@@ -101,7 +101,7 @@ struct ProjectSidebar: View {
                         branchName: appEnv.branchName(for: workstream.worktreePath),
                         worktreePath: workstream.worktreePath,
                         isPathValid: appEnv.isPathValid(workstream.worktreePath),
-                        hasActivePort: Self.hasPort(workstream.id),
+                        hasActivePort: appEnv.hasActivePort(workstream.id),
                         onArchive: { confirmArchive(workstream) }
                     )
                     .tag(SidebarSelection.workstream(workstream.id))
@@ -336,10 +336,6 @@ struct ProjectSidebar: View {
 
     @AppStorage("factoryfloor.bypassPermissions") private var defaultBypass: Bool = false
     @AppStorage("factoryfloor.symlinkEnv") private var symlinkEnv: Bool = true
-
-    private static func hasPort(_ workstreamID: UUID) -> Bool {
-        RunStateStore.loadValidated(for: workstreamID)?.detectedPorts.isEmpty == false
-    }
 
     private func addWorkstream(for projectID: UUID, bypassPermissions: Bool? = nil) {
         logger.warning("[FF] addWorkstream called for projectID=\(projectID, privacy: .public)")


### PR DESCRIPTION
## Summary
- **ProjectSidebar** was calling `GitOperations.isGitRepo` (filesystem check) and `RunStateStore.loadValidated` (file read + JSON decode + process check) synchronously during every SwiftUI view body evaluation, contributing to 5000ms+ app hangs
- Moved both checks into `AppEnvironment`'s existing background refresh cycle alongside `pathValidityCache`/`branchNameCache`
- Sidebar now uses cached dictionary/set lookups instead of synchronous I/O

Fixes FACTORY-FLOOR-A

## Test plan
- [x] Build succeeds
- [x] 118 tests pass
- [ ] Verify sidebar still shows git repo status and active port indicators correctly
- [ ] Confirm no app hangs in Sentry after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)