### PR TITLE
fix: detect CLI tools in fish shell and Nix environments

### DIFF
--- a/Sources/Models/CommandLineTools.swift
+++ b/Sources/Models/CommandLineTools.swift
@@ -40,6 +40,8 @@ enum CommandLineTools {
             "/usr/local/bin/\(name)",
             "/usr/bin/\(name)",
             "\(NSHomeDirectory())/.local/bin/\(name)",
+            "/run/current-system/sw/bin/\(name)",
+            "\(NSHomeDirectory())/.nix-profile/bin/\(name)",
         ]
 
         for location in knownLocations where isExecutable(location) {

--- a/Tests/CommandLineToolsTests.swift
+++ b/Tests/CommandLineToolsTests.swift
@@ -76,6 +76,31 @@ final class CommandLineToolsTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
+    func testFallsBackToNixSystemLocation() {
+        let resolved = CommandLineTools.path(
+            for: "tmux",
+            environment: ["PATH": "", "SHELL": "/bin/zsh"],
+            isExecutable: { $0 == "/run/current-system/sw/bin/tmux" },
+            resolveFromPath: { _, _ in nil },
+            resolveFromShellPath: { _ in "/usr/bin:/bin" }
+        )
+
+        XCTAssertEqual(resolved, "/run/current-system/sw/bin/tmux")
+    }
+
+    func testFallsBackToNixProfileLocation() {
+        let nixProfilePath = "\(NSHomeDirectory())/.nix-profile/bin/gh"
+        let resolved = CommandLineTools.path(
+            for: "gh",
+            environment: ["PATH": "", "SHELL": "/bin/zsh"],
+            isExecutable: { $0 == nixProfilePath },
+            resolveFromPath: { _, _ in nil },
+            resolveFromShellPath: { _ in "/usr/bin:/bin" }
+        )
+
+        XCTAssertEqual(resolved, nixProfilePath)
+    }
+
     func testSkipsShellPathWhenShellNotSet() {
         // No SHELL in environment, should skip shell PATH and fall through
         let resolved = CommandLineTools.path(


### PR DESCRIPTION
- Use `printenv PATH` instead of `echo $PATH` when resolving the user's login shell PATH. Shells that treat PATH as a list type (fish, nushell, elvish) output space-separated entries from `echo`, breaking the colon-split lookup. `printenv` reads the environment variable directly, which is always colon-separated at the OS level.
- Add `/run/current-system/sw/bin/` (nix-darwin) and `~/.nix-profile/bin/` (plain Nix) to the Tier 3 well-known locations fallback list.
