### PR TITLE
fix: sidebar branch name delay and improve workstream row content

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -326,6 +326,7 @@ struct ContentView: View {
                 if let wi = projects[pi].workstreams.firstIndex(where: { $0.id == workstreamID }) {
                     projects[pi].workstreams[wi].worktreePath = worktreePath
                     ProjectStore.save(projects)
+                    appEnvironment.refreshPathValidity(projects: projects)
                     logger.warning("[FF] workstreamWorktreeReady: updated \(workstreamID, privacy: .public) with path \(worktreePath, privacy: .public)")
                     return
                 }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -96,12 +96,16 @@ struct ProjectSidebar: View {
             if hasChildren && expandedProjects.contains(project.id) {
                 let sortedWS = project.workstreams.sorted { $0.lastAccessedAt > $1.lastAccessedAt }
                 ForEach(sortedWS) { workstream in
+                    let branch = appEnv.branchName(for: workstream.worktreePath)
+                    let pr = branch.flatMap { appEnv.githubPR(for: project.directory, branch: $0) }
                     WorkstreamRow(
                         name: workstream.name,
-                        branchName: appEnv.branchName(for: workstream.worktreePath),
+                        branchName: branch,
                         worktreePath: workstream.worktreePath,
                         isPathValid: appEnv.isPathValid(workstream.worktreePath),
                         hasActivePort: appEnv.hasActivePort(workstream.id),
+                        prTitle: pr?.title,
+                        prNumber: pr?.number,
                         onArchive: { confirmArchive(workstream) }
                     )
                     .tag(SidebarSelection.workstream(workstream.id))
@@ -648,39 +652,51 @@ private struct WorkstreamRow: View {
     var worktreePath: String?
     let isPathValid: Bool
     var hasActivePort: Bool = false
+    var prTitle: String?
+    var prNumber: Int?
     let onArchive: () -> Void
 
     @State private var isHovering = false
 
+    /// Subtext to display below the workstream name.
+    /// Priority: PR title (#number) > branch name (only if different from workstream name)
+    private var subtitle: String? {
+        guard isPathValid else { return nil }
+        if let prTitle, let prNumber {
+            return "\(prTitle) #\(prNumber)"
+        }
+        if let branchName, branchName != name {
+            return branchName
+        }
+        return nil
+    }
+
     var body: some View {
         HStack {
-            Label {
-                VStack(alignment: .leading, spacing: 1) {
-                    HStack(spacing: 4) {
-                        Text(name)
-                            .font(.system(.body))
-                            .strikethrough(!isPathValid)
-                            .foregroundStyle(isPathValid ? .primary : .secondary)
-                        if hasActivePort {
-                            Image(systemName: "circle.fill")
-                                .font(.system(size: 6))
-                                .foregroundStyle(.green)
-                        }
-                    }
-                    if let branchName, isPathValid {
-                        HStack(spacing: 3) {
-                            Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9))
-                            Text(branchName)
-                                .font(.system(size: 10))
-                        }
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
+            if !isPathValid {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 12))
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 4) {
+                    Text(name)
+                        .font(.system(.body))
+                        .strikethrough(!isPathValid)
+                        .foregroundStyle(isPathValid ? .primary : .secondary)
+                    if hasActivePort {
+                        Image(systemName: "circle.fill")
+                            .font(.system(size: 6))
+                            .foregroundStyle(.green)
                     }
                 }
-            } icon: {
-                Image(systemName: isPathValid ? "terminal" : "exclamationmark.triangle")
-                    .foregroundStyle(isPathValid ? Color.secondary : Color.orange)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
             }
 
             Spacer()

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,15 @@
 
 - [ ] Auto-update mechanism (Sparkle): in-app update for direct DMG users
 
+## Bugs
+
+- [x] Branch name doesn't appear in sidebar after workstream creation until the 15s refresh timer fires. Fixed: call `refreshPathValidity` immediately in the `.workstreamWorktreeReady` handler.
+
+## UI improvements
+
+- [x] Sidebar workstream rows: removed repetitive terminal icons, kept warning icon only for invalid paths
+- [x] Sidebar workstream subtext: show PR title (#number) when available, fall back to branch name only when it differs from the workstream name
+
 ## Future
 
 - [ ] External Chrome integration: launch with --remote-debugging-port for WebMCP/CDP


### PR DESCRIPTION
## Summary
- Fix branch name not appearing in sidebar after workstream creation (was waiting up to 15s for timer refresh)
- Remove repetitive terminal icons from workstream rows, keeping warning icon only for invalid paths
- Show PR title (#number) as subtext when available, fall back to branch name only when it differs from workstream name

## Test plan
- [x] Build succeeds
- [x] 118 tests pass
- [ ] Create a new workstream and verify branch name appears immediately
- [ ] Verify workstream rows no longer show terminal icon, but invalid paths still show warning icon
- [ ] Verify PR title shows as subtext when a PR exists for the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)