### PR TITLE
feat: add Reveal in Finder and Open in External Terminal to sidebar context menus

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -165,6 +165,11 @@
 "Opens the current workstream directory" = "Obre el directori del flux de treball actual";
 "Open in external browser" = "Obre al navegador extern";
 "Open in external terminal" = "Obre al terminal extern";
+"Open in External Terminal" = "Obre al terminal extern";
+"Reveal in Finder" = "Mostra al Finder";
+"Copy project path" = "Copia la ruta del projecte";
+"Copy branch name" = "Copia el nom de la branca";
+"Copy worktree path" = "Copia la ruta del worktree";
 
 /* Agent tab - Claude not installed */
 "Claude Code not found" = "Claude Code no trobat";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -165,6 +165,11 @@
 "Opens the current workstream directory" = "Opens the current workstream directory";
 "Open in external browser" = "Open in external browser";
 "Open in external terminal" = "Open in external terminal";
+"Open in External Terminal" = "Open in External Terminal";
+"Reveal in Finder" = "Reveal in Finder";
+"Copy project path" = "Copy project path";
+"Copy branch name" = "Copy branch name";
+"Copy worktree path" = "Copy worktree path";
 
 /* Agent tab - Claude not installed */
 "Claude Code not found" = "Claude Code not found";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -165,6 +165,11 @@
 "Opens the current workstream directory" = "Abre el directorio del flujo de trabajo actual";
 "Open in external browser" = "Abrir en navegador externo";
 "Open in external terminal" = "Abrir en terminal externo";
+"Open in External Terminal" = "Abrir en terminal externo";
+"Reveal in Finder" = "Mostrar en Finder";
+"Copy project path" = "Copiar ruta del proyecto";
+"Copy branch name" = "Copiar nombre de la rama";
+"Copy worktree path" = "Copiar ruta del worktree";
 
 /* Agent tab - Claude not installed */
 "Claude Code not found" = "Claude Code no encontrado";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -165,6 +165,11 @@
 "Opens the current workstream directory" = "Öppnar det aktuella arbetsflödets katalog";
 "Open in external browser" = "Öppna i extern webbläsare";
 "Open in external terminal" = "Öppna i extern terminal";
+"Open in External Terminal" = "Öppna i extern terminal";
+"Reveal in Finder" = "Visa i Finder";
+"Copy project path" = "Kopiera projektsökväg";
+"Copy branch name" = "Kopiera grennamn";
+"Copy worktree path" = "Kopiera worktree-sökväg";
 
 /* Agent tab - Claude not installed */
 "Claude Code not found" = "Claude Code hittades inte";

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -554,6 +554,20 @@ private func copyTextToPasteboard(_ text: String) {
     NSPasteboard.general.setString(text, forType: .string)
 }
 
+/// Opens a directory in the user's configured terminal, falling back to Apple Terminal.
+private func openDirectoryInTerminal(_ directory: String) {
+    let terminalBundleID = UserDefaults.standard.string(forKey: "factoryfloor.defaultTerminal") ?? ""
+    let appURL: URL?
+    if !terminalBundleID.isEmpty {
+        appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: terminalBundleID)
+    } else {
+        appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.Terminal")
+    }
+    guard let appURL else { return }
+    let config = NSWorkspace.OpenConfiguration()
+    NSWorkspace.shared.open([URL(fileURLWithPath: directory)], withApplicationAt: appURL, configuration: config)
+}
+
 private struct ProjectHeaderRow: View {
     let project: Project
     let isExpanded: Bool
@@ -638,6 +652,17 @@ private struct ProjectHeaderRow: View {
         .onHover { isHovering = $0 }
         .contextMenu {
             Button {
+                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: project.directory)
+            } label: {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            Button {
+                openDirectoryInTerminal(project.directory)
+            } label: {
+                Label("Open in External Terminal", systemImage: "terminal")
+            }
+            Divider()
+            Button {
                 copyTextToPasteboard(project.directory)
             } label: {
                 Label("Copy project path", systemImage: "doc.on.doc")
@@ -709,6 +734,19 @@ private struct WorkstreamRow: View {
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .contextMenu {
+            if let worktreePath {
+                Button {
+                    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktreePath)
+                } label: {
+                    Label("Reveal in Finder", systemImage: "folder")
+                }
+                Button {
+                    openDirectoryInTerminal(worktreePath)
+                } label: {
+                    Label("Open in External Terminal", systemImage: "terminal")
+                }
+                Divider()
+            }
             if let branchName {
                 Button {
                     copyTextToPasteboard(branchName)


### PR DESCRIPTION
## Summary
- Adds **Reveal in Finder** and **Open in External Terminal** to the right-click context menu on both project rows and workstream rows in the sidebar
- Uses the user's configured default terminal (falls back to Apple Terminal)
- Adds localized strings for all context menu items (en, ca, es, sv)

## Test plan
- [ ] Right-click a project in the sidebar, verify "Reveal in Finder" opens the project directory
- [ ] Right-click a project, verify "Open in External Terminal" opens the configured terminal at the project directory
- [ ] Right-click a workstream, verify both actions work with the worktree path
- [ ] Verify existing context menu items (copy path, copy branch name) still work
- [ ] Test with a non-default terminal configured in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)