### PR TITLE
feat: adopt existing worktrees as workstreams and enrich status

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -77,6 +77,8 @@
 "Prune" = "Neteja";
 "Clean" = "Net";
 "Uncommitted changes" = "Canvis sense confirmar";
+"Commits ahead" = "Commits per endavant";
+"Open as workstream" = "Obre com a flux de treball";
 "Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Arbres de treball al disc per a aquest repositori. La neteja elimina els arbres de treball nets i els seus fluxos de treball associats.";
 "Prune %d clean worktree" = "Neteja %d arbre de treball net";
 "Prune %d clean worktrees" = "Neteja %d arbres de treball nets";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -77,6 +77,8 @@
 "Prune" = "Prune";
 "Clean" = "Clean";
 "Uncommitted changes" = "Uncommitted changes";
+"Commits ahead" = "Commits ahead";
+"Open as workstream" = "Open as workstream";
 "Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams.";
 "Prune %d clean worktree" = "Prune %d clean worktree";
 "Prune %d clean worktrees" = "Prune %d clean worktrees";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -77,6 +77,8 @@
 "Prune" = "Limpiar";
 "Clean" = "Limpio";
 "Uncommitted changes" = "Cambios sin confirmar";
+"Commits ahead" = "Commits por delante";
+"Open as workstream" = "Abrir como flujo de trabajo";
 "Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Árboles de trabajo en disco para este repositorio. La limpieza elimina los árboles de trabajo limpios y sus flujos de trabajo asociados.";
 "Prune %d clean worktree" = "Limpiar %d árbol de trabajo limpio";
 "Prune %d clean worktrees" = "Limpiar %d árboles de trabajo limpios";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -77,6 +77,8 @@
 "Prune" = "Rensa";
 "Clean" = "Rent";
 "Uncommitted changes" = "Osparade ändringar";
+"Commits ahead" = "Commits före";
+"Open as workstream" = "Öppna som arbetsflöde";
 "Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Arbetsträd på disk för detta repository. Rensning tar bort rena arbetsträd och deras associerade arbetsflöden.";
 "Prune %d clean worktree" = "Rensa %d rent arbetsträd";
 "Prune %d clean worktrees" = "Rensa %d rena arbetsträd";

--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -307,6 +307,25 @@ final class AppEnvironment: ObservableObject {
     private var lastBranchPRRefresh: Date = .distantPast
 
     /// Refresh PRs for all workstream branches. One gh call per project.
+    /// Populate the branch PR cache for a set of branches in a single `gh` call.
+    func refreshBranchPRs(for directory: String, branches: Set<String>) {
+        guard ghAvailable, let ghPath = toolStatus.gh.path, !branches.isEmpty else { return }
+        Task.detached {
+            let prs = GitHubOperations.openPRs(ghPath: ghPath, at: directory, limit: 100)
+            let prsByBranch = Dictionary(prs.map { ($0.branch, $0) }, uniquingKeysWith: { first, _ in first })
+            await MainActor.run {
+                for branch in branches {
+                    let key = "\(directory)|\(branch)"
+                    if let pr = prsByBranch[branch] {
+                        self.githubBranchPRCache[key] = pr
+                    } else {
+                        self.githubBranchPRCache.removeValue(forKey: key)
+                    }
+                }
+            }
+        }
+    }
+
     /// Throttled to run at most every 30 seconds.
     func refreshAllBranchPRs(projects: [Project]) {
         let now = Date()

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -19,6 +19,8 @@ struct WorktreeInfo: Identifiable {
     let branch: String?
     let isDirty: Bool
     let isMain: Bool
+    let hasUnpushedCommits: Bool
+    let hasBranchCommits: Bool
 
     var id: String {
         path
@@ -235,7 +237,9 @@ enum GitOperations {
                 if let path = currentPath {
                     let isMain = URL(fileURLWithPath: path).standardizedFileURL.path == mainPath
                     let dirty = !isMain && hasUncommittedChanges(at: path)
-                    results.append(WorktreeInfo(path: path, branch: currentBranch, isDirty: dirty, isMain: isMain))
+                    let unpushed = !isMain && hasUnpushedCommits(at: path)
+                    let branchCommits = !isMain && hasBranchCommits(at: path, projectPath: projectPath)
+                    results.append(WorktreeInfo(path: path, branch: currentBranch, isDirty: dirty, isMain: isMain, hasUnpushedCommits: unpushed, hasBranchCommits: branchCommits))
                 }
                 currentPath = String(line.dropFirst("worktree ".count))
                 currentBranch = nil
@@ -247,18 +251,20 @@ enum GitOperations {
         if let path = currentPath {
             let isMain = URL(fileURLWithPath: path).standardizedFileURL.path == mainPath
             let dirty = !isMain && hasUncommittedChanges(at: path)
-            results.append(WorktreeInfo(path: path, branch: currentBranch, isDirty: dirty, isMain: isMain))
+            let unpushed = !isMain && hasUnpushedCommits(at: path)
+            let branchCommits = !isMain && hasBranchCommits(at: path, projectPath: projectPath)
+            results.append(WorktreeInfo(path: path, branch: currentBranch, isDirty: dirty, isMain: isMain, hasUnpushedCommits: unpushed, hasBranchCommits: branchCommits))
         }
 
         return results
     }
 
-    /// Remove all worktrees that have no uncommitted changes. Returns count of pruned worktrees.
+    /// Remove all worktrees that have no uncommitted changes and no unmerged branch commits.
     @discardableResult
     static func pruneCleanWorktrees(at projectPath: String) -> Int {
         let worktrees = listWorktreesWithInfo(at: projectPath)
         var pruned = 0
-        for wt in worktrees where !wt.isMain && !wt.isDirty {
+        for wt in worktrees where !wt.isMain && !wt.isDirty && !wt.hasBranchCommits {
             let result = run(args: ["worktree", "remove", wt.path], in: projectPath)
             if result != nil {
                 pruned += 1

--- a/Sources/Views/ProjectOverviewView.swift
+++ b/Sources/Views/ProjectOverviewView.swift
@@ -177,7 +177,12 @@ struct ProjectOverviewView: View {
                 if !worktrees.isEmpty {
                     Section {
                         ForEach(worktrees) { wt in
-                            WorktreeInfoRow(worktree: wt)
+                            WorktreeInfoRow(
+                                worktree: wt,
+                                projectDirectory: project.directory,
+                                isWorkstream: workstreamPaths.contains(wt.path),
+                                onAdopt: { adoptWorktree(wt) }
+                            )
                         }
 
                         if prunableCount > 0 {
@@ -247,8 +252,22 @@ struct ProjectOverviewView: View {
         }
     }
 
+    private var workstreamPaths: Set<String> {
+        Set(project.workstreams.compactMap(\.worktreePath))
+    }
+
     private var prunableCount: Int {
-        worktrees.filter { !$0.isMain && !$0.isDirty }.count
+        worktrees.filter { !$0.isMain && !$0.isDirty && !$0.hasBranchCommits }.count
+    }
+
+    private func adoptWorktree(_ worktree: WorktreeInfo) {
+        let name = worktree.branch ?? worktree.path.components(separatedBy: "/").last ?? "workstream"
+        let workstream = Workstream(name: name, worktreePath: worktree.path)
+        NotificationCenter.default.post(
+            name: .workstreamCreated,
+            object: nil,
+            userInfo: ["projectID": project.id, "workstream": workstream]
+        )
     }
 
     private func refreshWorktrees() {
@@ -256,6 +275,11 @@ struct ProjectOverviewView: View {
         Task.detached {
             let wts = GitOperations.listWorktreesWithInfo(at: dir)
             await updateWorktrees(wts)
+            // Populate PR cache for worktree branches
+            let branches = Set(wts.compactMap(\.branch))
+            await MainActor.run {
+                appEnv.refreshBranchPRs(for: dir, branches: branches)
+            }
         }
     }
 
@@ -270,7 +294,7 @@ struct ProjectOverviewView: View {
     private func pruneWorktrees() {
         isPruning = true
         let dir = project.directory
-        let prunablePaths = Set(worktrees.filter { !$0.isMain && !$0.isDirty }.map(\.path))
+        let prunablePaths = Set(worktrees.filter { !$0.isMain && !$0.isDirty && !$0.hasBranchCommits }.map(\.path))
         Task.detached {
             GitOperations.pruneCleanWorktrees(at: dir)
             await applyPrunedWorktrees(prunablePaths)
@@ -311,37 +335,86 @@ struct ProjectOverviewView: View {
 
 private struct WorktreeInfoRow: View {
     let worktree: WorktreeInfo
+    let projectDirectory: String
+    let isWorkstream: Bool
+    let onAdopt: () -> Void
+
+    @EnvironmentObject var appEnv: AppEnvironment
+
+    private var pr: GitHubPR? {
+        guard let branch = worktree.branch else { return nil }
+        return appEnv.githubPR(for: projectDirectory, branch: branch)
+    }
 
     var body: some View {
         HStack {
             Image(systemName: worktree.isMain ? "folder.fill" : "arrow.triangle.branch")
                 .foregroundStyle(worktree.isMain ? .blue : .secondary)
-                .frame(width: 20)
+                .frame(width: 20, alignment: .top)
+                .padding(.top, 4)
             VStack(alignment: .leading, spacing: 2) {
                 Text(worktree.branch ?? "detached")
                     .font(.system(.body, design: .monospaced))
                 Text(worktree.path.abbreviatedPath)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                if !worktree.isMain {
+                    HStack(spacing: 8) {
+                        if let pr {
+                            HStack(spacing: 3) {
+                                Image(systemName: "arrow.triangle.pull")
+                                    .font(.system(size: 10))
+                                Text(verbatim: "#\(pr.number)")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(.purple)
+                        }
+                        if worktree.isDirty {
+                            HStack(spacing: 4) {
+                                Circle()
+                                    .fill(.orange)
+                                    .frame(width: 6, height: 6)
+                                Text("Uncommitted changes")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                            }
+                        } else if worktree.hasBranchCommits {
+                            HStack(spacing: 4) {
+                                Image(systemName: "arrow.up.circle.fill")
+                                    .font(.system(size: 10))
+                                Text("Commits ahead")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(.blue)
+                        } else {
+                            Text("Clean")
+                                .font(.caption)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
             }
+            .frame(minHeight: 36, alignment: .leading)
             Spacer()
             if worktree.isMain {
                 Text("main")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            } else if worktree.isDirty {
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(.orange)
-                        .frame(width: 6, height: 6)
-                    Text("Uncommitted changes")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
+            } else if !isWorkstream {
+                Button(action: onAdopt) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus.rectangle.on.folder")
+                            .font(.system(size: 12))
+                        Text("Open")
+                            .font(.caption)
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.primary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
-            } else {
-                Text("Clean")
-                    .font(.caption)
-                    .foregroundStyle(.green)
+                .buttonStyle(.plain)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add "Open" button to worktree rows in project overview to adopt existing git worktrees as workstreams (name derived from branch)
- Enrich worktree status with PR numbers, "commits ahead" indicator, and icons
- Fix pruning to skip worktrees with unmerged branch commits (pre-existing bug)

## Test plan
- [ ] Open a project with existing git worktrees not linked to workstreams
- [ ] Verify "Open" button appears on non-main, non-workstream worktree rows
- [ ] Click "Open" and verify worktree appears as a workstream in the sidebar
- [ ] Verify worktrees with commits ahead show blue "Commits ahead" status
- [ ] Verify worktrees with open PRs show purple PR number
- [ ] Verify prune button excludes worktrees with commits ahead

🤖 Generated with [Claude Code](https://claude.com/claude-code)