### PR TITLE
fix: skip submodule dirty checks in git status

### DIFF
--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -62,7 +62,7 @@ enum GitOperations {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let commitCount = countStr.flatMap(Int.init)
 
-        let status = run(args: ["status", "--porcelain"], in: path)?
+        let status = run(args: ["status", "--porcelain", "--ignore-submodules=dirty"], in: path)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let isDirty = status.map { !$0.isEmpty } ?? false
 
@@ -170,7 +170,7 @@ enum GitOperations {
 
     /// Check if a worktree has uncommitted changes (staged, unstaged, or untracked files).
     static func hasUncommittedChanges(at path: String) -> Bool {
-        guard let status = run(args: ["status", "--porcelain"], in: path) else { return false }
+        guard let status = run(args: ["status", "--porcelain", "--ignore-submodules=dirty"], in: path) else { return false }
         return !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 


### PR DESCRIPTION
## Summary
- Add `--ignore-submodules=dirty` to `git status --porcelain` calls used for dirty state detection
- Without this flag, git recursively inspects submodule state which can hang or fail in worktrees where submodules aren't initialized, preventing the commit action button from appearing

## Test plan
- [ ] Open a project that has git submodules
- [ ] Create a workstream and add a file
- [ ] Verify the commit action button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)