### PR TITLE
feat: collapse doc tabs by default and pin to bottom

### DIFF
--- a/Sources/Views/ProjectOverviewView.swift
+++ b/Sources/Views/ProjectOverviewView.swift
@@ -207,7 +207,16 @@ struct ProjectOverviewView: View {
             }
             .formStyle(.grouped)
 
-            // Doc tabs
+            // Markdown content
+            if let selected = selectedDoc,
+               let doc = docFiles.first(where: { $0.name == selected })
+            {
+                Divider()
+                MarkdownContentView(markdown: doc.content)
+                    .id(selected)
+            }
+
+            // Doc tabs pinned to bottom
             if !docFiles.isEmpty {
                 Divider()
                 HStack(spacing: 0) {
@@ -215,21 +224,13 @@ struct ProjectOverviewView: View {
                         DocTabButton(
                             name: doc.name,
                             isActive: selectedDoc == doc.name,
-                            action: { selectedDoc = doc.name }
+                            action: { selectedDoc = selectedDoc == doc.name ? nil : doc.name }
                         )
                     }
                     Spacer()
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 4)
-                Divider()
-
-                if let selected = selectedDoc,
-                   let doc = docFiles.first(where: { $0.name == selected })
-                {
-                    MarkdownContentView(markdown: doc.content)
-                        .id(selected)
-                }
             }
         } // VStack
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -294,7 +295,6 @@ struct ProjectOverviewView: View {
     @MainActor
     private func updateDocFiles(_ docFiles: [DocFile]) {
         self.docFiles = docFiles
-        selectedDoc = docFiles.first?.name
     }
 
     @MainActor

--- a/Sources/Views/WorkstreamInfoView.swift
+++ b/Sources/Views/WorkstreamInfoView.swift
@@ -110,7 +110,19 @@ struct WorkstreamInfoView: View {
                 .padding(.vertical, 6)
             }
 
-            // Pinned doc tabs
+            Divider()
+
+            // Markdown content fills available space
+            if let selected = selectedDoc,
+               let doc = docFiles.first(where: { $0.name == selected })
+            {
+                MarkdownContentView(markdown: doc.content)
+                    .id(selected)
+            } else {
+                Spacer()
+            }
+
+            // Doc tabs pinned to bottom
             if !docFiles.isEmpty {
                 Divider()
                 HStack(spacing: 0) {
@@ -118,25 +130,13 @@ struct WorkstreamInfoView: View {
                         DocTabButton(
                             name: doc.name,
                             isActive: selectedDoc == doc.name,
-                            action: { selectedDoc = doc.name }
+                            action: { selectedDoc = selectedDoc == doc.name ? nil : doc.name }
                         )
                     }
                     Spacer()
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 4)
-            }
-
-            Divider()
-
-            // Scrollable: only the markdown content
-            if let selected = selectedDoc,
-               let doc = docFiles.first(where: { $0.name == selected })
-            {
-                MarkdownContentView(markdown: doc.content)
-                    .id(selected)
-            } else if docFiles.isEmpty {
-                Spacer()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -210,7 +210,6 @@ struct WorkstreamInfoView: View {
     @MainActor
     private func updateDocFiles(_ docFiles: [DocFile]) {
         self.docFiles = docFiles
-        selectedDoc = docFiles.first?.name
     }
 }
 
@@ -330,7 +329,7 @@ struct DocTabButton: View {
                 .padding(.vertical, 3)
                 .background(isActive ? Color.primary.opacity(0.08) : (isHovering ? Color.primary.opacity(0.04) : .clear))
                 .clipShape(RoundedRectangle(cornerRadius: 4))
-                .foregroundStyle(isActive ? .primary : .tertiary)
+                .foregroundStyle(isActive ? .primary : .secondary)
         }
         .buttonStyle(.borderless)
         .onHover { isHovering = $0 }


### PR DESCRIPTION
## Summary
- Doc file tabs (README, CLAUDE, AGENTS) start collapsed instead of auto-opening the first file
- Clicking a tab toggles its content visibility
- Tab bar pinned to the bottom of both workstream info and project overview views
- Improved inactive tab text contrast (tertiary → secondary)

## Test plan
- [ ] Open a workstream info view — no doc content shown by default
- [ ] Click a doc tab — content appears; click again — content hides
- [ ] Tab bar stays at the bottom in both project overview and workstream info
- [ ] Verify symlinked doc files (e.g. CLAUDE.md → AGENTS.md) are correctly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)