### PR TITLE
feat: detect merged PRs and show archive prompt

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -262,6 +262,7 @@
 "Push" = "Push";
 "Create PR" = "Crear PR";
 "Abandon PR" = "Abandonar PR";
+"This branch has been merged." = "Aquesta branca s'ha fusionat.";
 "gh CLI is not installed." = "gh CLI no està instal·lat.";
 "Claude Code is not installed." = "Claude Code no està instal·lat.";
 "Enable \"Bypass permission prompts\" in Settings." = "Activa \"Ometre els permisos\" a Configuració.";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -262,6 +262,7 @@
 "Push" = "Push";
 "Create PR" = "Create PR";
 "Abandon PR" = "Abandon PR";
+"This branch has been merged." = "This branch has been merged.";
 "gh CLI is not installed." = "gh CLI is not installed.";
 "Claude Code is not installed." = "Claude Code is not installed.";
 "Enable \"Bypass permission prompts\" in Settings." = "Enable \"Bypass permission prompts\" in Settings.";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -262,6 +262,7 @@
 "Push" = "Push";
 "Create PR" = "Crear PR";
 "Abandon PR" = "Abandonar PR";
+"This branch has been merged." = "Esta rama ha sido fusionada.";
 "gh CLI is not installed." = "gh CLI no está instalado.";
 "Claude Code is not installed." = "Claude Code no está instalado.";
 "Enable \"Bypass permission prompts\" in Settings." = "Activa \"Omitir permisos\" en Configuración.";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -262,6 +262,7 @@
 "Push" = "Push";
 "Create PR" = "Skapa PR";
 "Abandon PR" = "Överge PR";
+"This branch has been merged." = "Denna gren har mergats.";
 "gh CLI is not installed." = "gh CLI är inte installerat.";
 "Claude Code is not installed." = "Claude Code är inte installerat.";
 "Enable \"Bypass permission prompts\" in Settings." = "Aktivera \"Hoppa över behörighetsfrågor\" i Inställningar.";

--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -290,6 +290,9 @@ final class AppEnvironment: ObservableObject {
             var branchPR: GitHubPR?
             if let branch {
                 branchPR = GitHubOperations.prForBranch(ghPath: ghPath, at: directory, branch: branch)
+                if branchPR == nil {
+                    branchPR = GitHubOperations.mergedPRForBranch(ghPath: ghPath, at: directory, branch: branch)
+                }
             }
 
             await MainActor.run {
@@ -331,8 +334,20 @@ final class AppEnvironment: ObservableObject {
 
         guard !projectBranches.isEmpty else { return }
 
+        // Snapshot currently cached PR states to detect transitions
+        var cachedStates: [String: String] = [:]
+        for (dir, branches) in projectBranches {
+            for branch in branches {
+                let key = "\(dir)|\(branch)"
+                if let pr = githubBranchPRCache[key] {
+                    cachedStates[key] = pr.state
+                }
+            }
+        }
+
         Task.detached {
             // One gh call per project fetches all open PRs
+            var allOpenPRs: [(String, [GitHubPR])] = []
             await withTaskGroup(of: (String, [GitHubPR]).self) { group in
                 for (dir, _) in projectBranches {
                     group.addTask {
@@ -340,18 +355,48 @@ final class AppEnvironment: ObservableObject {
                         return (dir, prs)
                     }
                 }
-                for await (dir, prs) in group {
-                    let branches = projectBranches[dir] ?? []
-                    // Build a lookup from branch name to PR
-                    let prsByBranch = Dictionary(prs.map { ($0.branch, $0) }, uniquingKeysWith: { first, _ in first })
+                for await result in group {
+                    allOpenPRs.append(result)
+                }
+            }
 
-                    await MainActor.run {
-                        for branch in branches {
-                            let key = "\(dir)|\(branch)"
-                            if let pr = prsByBranch[branch] {
+            // Update cache with open PRs, collect branches needing merged lookup
+            var mergedLookups: [(dir: String, branch: String, key: String)] = []
+            for (dir, prs) in allOpenPRs {
+                let branches = projectBranches[dir] ?? []
+                let prsByBranch = Dictionary(prs.map { ($0.branch, $0) }, uniquingKeysWith: { first, _ in first })
+
+                await MainActor.run {
+                    for branch in branches {
+                        let key = "\(dir)|\(branch)"
+                        if let pr = prsByBranch[branch] {
+                            self.githubBranchPRCache[key] = pr
+                        } else if cachedStates[key] == "MERGED" {
+                            // Already cached as merged, no need to re-fetch
+                        } else if cachedStates[key] != nil {
+                            // Had an open PR that's no longer open, check if merged
+                            mergedLookups.append((dir: dir, branch: branch, key: key))
+                            self.githubBranchPRCache.removeValue(forKey: key)
+                        } else {
+                            // Never had a cached PR, nothing to do
+                        }
+                    }
+                }
+            }
+
+            // Targeted merged lookups for branches whose open PR disappeared
+            if !mergedLookups.isEmpty {
+                await withTaskGroup(of: (String, GitHubPR?).self) { group in
+                    for lookup in mergedLookups {
+                        group.addTask {
+                            let pr = GitHubOperations.mergedPRForBranch(ghPath: ghPath, at: lookup.dir, branch: lookup.branch)
+                            return (lookup.key, pr)
+                        }
+                    }
+                    for await (key, pr) in group {
+                        if let pr {
+                            await MainActor.run {
                                 self.githubBranchPRCache[key] = pr
-                            } else {
-                                self.githubBranchPRCache.removeValue(forKey: key)
                             }
                         }
                     }

--- a/Sources/Models/GitHubOperations.swift
+++ b/Sources/Models/GitHubOperations.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-struct GitHubRepoInfo: Sendable {
+struct GitHubRepoInfo {
     let name: String
     let url: String
     let description: String?
@@ -12,7 +12,7 @@ struct GitHubRepoInfo: Sendable {
     let openIssues: Int
 }
 
-struct GitHubPR: Sendable {
+struct GitHubPR {
     let number: Int
     let title: String
     let state: String
@@ -64,9 +64,24 @@ enum GitHubOperations {
         }
     }
 
-    /// Find a PR for a specific branch.
+    /// Find an open PR for a specific branch.
     static func prForBranch(ghPath: String, at path: String, branch: String) -> GitHubPR? {
         guard let json = run(ghPath, args: ["pr", "list", "--head", branch, "--json", "number,title,state,headRefName,url", "--limit", "1"], in: path) else { return nil }
+        guard let data = json.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let dict = array.first else { return nil }
+
+        guard let number = dict["number"] as? Int,
+              let title = dict["title"] as? String,
+              let state = dict["state"] as? String,
+              let branch = dict["headRefName"] as? String,
+              let url = dict["url"] as? String else { return nil }
+        return GitHubPR(number: number, title: title, state: state, branch: branch, url: url)
+    }
+
+    /// Find a merged PR for a specific branch.
+    static func mergedPRForBranch(ghPath: String, at path: String, branch: String) -> GitHubPR? {
+        guard let json = run(ghPath, args: ["pr", "list", "--head", branch, "--state", "merged", "--json", "number,title,state,headRefName,url", "--limit", "1"], in: path) else { return nil }
         guard let data = json.data(using: .utf8),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
               let dict = array.first else { return nil }

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -11,6 +11,7 @@ extension Notification.Name {
     static let workstreamWorktreeReady = Notification.Name("factoryfloor.workstreamWorktreeReady")
     static let workstreamCreationFailed = Notification.Name("factoryfloor.workstreamCreationFailed")
     static let projectCreated = Notification.Name("factoryfloor.projectCreated")
+    static let archiveWorkstream = Notification.Name("factoryfloor.archiveWorkstream")
 }
 
 final class ProjectList: ObservableObject {
@@ -350,6 +351,11 @@ struct ContentView: View {
             selection = .project(project.id)
             ProjectStore.save(projects)
             logger.warning("[FF] projectCreated notification handled: \(project.name, privacy: .public)")
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .archiveWorkstream)) { notification in
+            if let wsID = notification.object as? UUID {
+                confirmArchive(wsID)
+            }
         }
         .onReceive(Timer.publish(every: 15, on: .main, in: .common).autoconnect()) { _ in
             appEnvironment.refreshAllRepoInfo(projects: projects)

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -106,6 +106,7 @@ struct ProjectSidebar: View {
                         hasActivePort: appEnv.hasActivePort(workstream.id),
                         prTitle: pr?.title,
                         prNumber: pr?.number,
+                        prState: pr?.state,
                         onArchive: { confirmArchive(workstream) }
                     )
                     .tag(SidebarSelection.workstream(workstream.id))
@@ -679,6 +680,7 @@ private struct WorkstreamRow: View {
     var hasActivePort: Bool = false
     var prTitle: String?
     var prNumber: Int?
+    var prState: String?
     let onArchive: () -> Void
 
     @State private var isHovering = false
@@ -717,10 +719,17 @@ private struct WorkstreamRow: View {
                     }
                 }
                 if let subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
+                    HStack(spacing: 3) {
+                        if prState == "MERGED" {
+                            Image(systemName: "arrow.triangle.merge")
+                                .font(.system(size: 8))
+                                .foregroundStyle(.purple)
+                        }
+                        Text(subtitle)
+                            .lineLimit(1)
+                    }
+                    .font(.system(size: 10))
+                    .foregroundStyle(prState == "MERGED" ? AnyShapeStyle(.purple) : AnyShapeStyle(.tertiary))
                 }
             }
 

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -331,18 +331,19 @@ struct TerminalContainerView: View {
             Spacer()
 
             if let pr = branchPR, let url = URL(string: pr.url) {
+                let prColor: Color = pr.state == "MERGED" ? .purple : .green
                 Button(action: { NSWorkspace.shared.open(url) }) {
                     HStack(spacing: 4) {
-                        Image(systemName: "arrow.triangle.pull")
+                        Image(systemName: pr.state == "MERGED" ? "arrow.triangle.merge" : "arrow.triangle.pull")
                             .font(.system(size: 11))
                         Text(verbatim: "#\(pr.number)")
                             .font(.system(size: 11, weight: .medium, design: .monospaced))
                     }
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Color.green.opacity(0.12))
+                    .background(prColor.opacity(0.12))
                     .clipShape(RoundedRectangle(cornerRadius: 5))
-                    .foregroundStyle(.green)
+                    .foregroundStyle(prColor)
                 }
                 .buttonStyle(.borderless)
                 .help(pr.title)
@@ -387,6 +388,7 @@ struct TerminalContainerView: View {
         switch activeTab {
         case .info:
             WorkstreamInfoView(
+                workstreamID: workstreamID,
                 workstreamName: workstreamName,
                 workingDirectory: workingDirectory,
                 projectName: projectName,
@@ -595,7 +597,7 @@ struct TerminalContainerView: View {
                         bypassPermissions: bypassPermissions,
                         worktreeState: appEnv.worktreeState(for: workingDirectory),
                         hasGitHubRemote: appEnv.hasGitHubRemote(projectDirectory),
-                        hasPR: branchPR != nil
+                        prState: branchPR?.state
                     )
                 }
             }
@@ -869,7 +871,11 @@ private struct QuickActionButtons: View {
     let bypassPermissions: Bool
     let worktreeState: WorktreeState
     let hasGitHubRemote: Bool
-    let hasPR: Bool
+    let prState: String?
+
+    private var hasOpenPR: Bool {
+        prState == "OPEN"
+    }
 
     private func isVisible(_ action: QuickAction) -> Bool {
         switch action {
@@ -878,9 +884,9 @@ private struct QuickActionButtons: View {
         case .push:
             return worktreeState.hasUnpushedCommits && worktreeState.hasRemote
         case .createPR:
-            return hasGitHubRemote && worktreeState.hasBranchCommits && !hasPR
+            return hasGitHubRemote && worktreeState.hasBranchCommits && prState == nil
         case .abandonPR:
-            return hasPR
+            return hasOpenPR
         }
     }
 

--- a/Sources/Views/WorkstreamInfoView.swift
+++ b/Sources/Views/WorkstreamInfoView.swift
@@ -4,6 +4,7 @@
 import SwiftUI
 
 struct WorkstreamInfoView: View {
+    let workstreamID: UUID
     let workstreamName: String
     let workingDirectory: String
     let projectName: String
@@ -65,10 +66,11 @@ struct WorkstreamInfoView: View {
                let pr = appEnv.githubPR(for: projectDirectory, branch: branch)
             {
                 Divider()
+                let prColor: Color = pr.state == "MERGED" ? .purple : pr.state == "OPEN" ? .green : .secondary
                 HStack(spacing: 8) {
-                    Image(systemName: "arrow.triangle.pull")
+                    Image(systemName: pr.state == "MERGED" ? "arrow.triangle.merge" : "arrow.triangle.pull")
                         .font(.system(size: 10))
-                        .foregroundStyle(.green)
+                        .foregroundStyle(prColor)
                     Text(verbatim: "#\(pr.number)")
                         .font(.system(size: 11, weight: .medium, design: .monospaced))
                     Text(pr.title)
@@ -78,10 +80,33 @@ struct WorkstreamInfoView: View {
                     Spacer()
                     Text(pr.state)
                         .font(.system(size: 10))
-                        .foregroundStyle(pr.state == "OPEN" ? .green : .secondary)
+                        .foregroundStyle(prColor)
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 6)
+
+                if pr.state == "MERGED" {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.purple)
+                        Text("This branch has been merged.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button(action: {
+                            NotificationCenter.default.post(name: .archiveWorkstream, object: workstreamID)
+                        }) {
+                            Text("Archive")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.purple)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 6)
+                    .background(Color.purple.opacity(0.06))
+                }
             }
 
             if scriptConfig.hasAnyScript {


### PR DESCRIPTION
## Summary
- Detect when a PR has been merged on GitHub by doing targeted `gh pr list --state merged` lookups for branches that previously had an open PR
- Show merged PRs with purple styling (matching GitHub) across the tab bar badge, info panel, and sidebar
- Display an archive banner in the workstream info panel prompting users to clean up completed workstreams
- Hide "Create PR" and "Abandon PR" quick actions for merged PRs

## Test plan
- [ ] Create a workstream, commit, push, and create a PR
- [ ] Merge the PR on GitHub
- [ ] Verify the PR badge turns purple with merge icon within ~30 seconds
- [ ] Verify the info panel shows "This branch has been merged." with Archive button
- [ ] Verify the sidebar shows purple merge icon and subtitle
- [ ] Verify "Create PR" button does not reappear
- [ ] Verify "Abandon PR" is hidden for merged PRs
- [ ] Verify clicking Archive triggers the archive confirmation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)