### PR TITLE
fix: preserve active tab when cycling workstreams

### DIFF
--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -538,14 +538,6 @@ struct TerminalContainerView: View {
                 guard n <= customTabs.count else { return }
                 activeTab = customTabs[n - 1]
             }
-            .onReceive(NotificationCenter.default.publisher(for: .nextTab)) { _ in
-                guard let idx = tabs.firstIndex(of: activeTab) else { return }
-                activeTab = tabs[(idx + 1) % tabs.count]
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .prevTab)) { _ in
-                guard let idx = tabs.firstIndex(of: activeTab) else { return }
-                activeTab = tabs[(idx - 1 + tabs.count) % tabs.count]
-            }
             .onReceive(NotificationCenter.default.publisher(for: .terminalTabExited)) { notification in
                 guard let surfaceID = notification.object as? UUID else { return }
                 if let tab = tabs.first(where: {


### PR DESCRIPTION
## Summary
- Removed duplicate `nextTab`/`prevTab` notification handlers from `TerminalContainerView`
- These handlers competed with `ContentView`'s workstream cycling, mutating the active tab on the departing workstream before `onDisappear` saved the snapshot
- Tab switching within a workstream still works via Cmd+Return, Cmd+I, Cmd+E, and Cmd+1-9

## Test plan
- [ ] Open a project with multiple workstreams, each with the agent tab active
- [ ] Use Cmd+Shift+[ to cycle through workstreams repeatedly
- [ ] Verify each workstream preserves its previously active tab
- [ ] Verify Cmd+Return, Cmd+I, Cmd+E, Cmd+1-9 still switch tabs within a workstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)