### PR TITLE
feat: background fetch of origin default branch every 2 minutes

### DIFF
--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -62,6 +62,30 @@ final class AppEnvironment: ObservableObject {
         }
     }
 
+    // MARK: - Origin Fetch
+
+    private var lastOriginFetch: [String: Date] = [:]
+    private static let originFetchInterval: TimeInterval = 120 // 2 minutes
+
+    /// Fetch the default branch from origin for each project directory.
+    /// Throttled to once every 2 minutes per project. Skips repos without
+    /// a remote and fails silently on network errors.
+    func fetchOrigin(projects: [Project]) {
+        let now = Date()
+        for project in projects {
+            let dir = project.directory
+            if let lastFetch = lastOriginFetch[dir],
+               now.timeIntervalSince(lastFetch) < Self.originFetchInterval
+            {
+                continue
+            }
+            lastOriginFetch[dir] = now
+            Task.detached {
+                GitOperations.fetchDefaultBranch(at: dir)
+            }
+        }
+    }
+
     // MARK: - Repo Info
 
     func repoInfo(for directory: String) -> GitRepoInfo? {

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -109,7 +109,6 @@ enum GitOperations {
             ? workstreamName
             : "\(branchPrefix)/\(workstreamName)"
 
-        fetchDefaultBranch(at: projectPath)
         let baseBranch = defaultBranch(at: projectPath)
 
         // Create parent directories
@@ -308,7 +307,7 @@ enum GitOperations {
 
     /// Fetch the default branch from origin. Fails silently when there is no
     /// remote or the network is unreachable.
-    private static func fetchDefaultBranch(at path: String) {
+    static func fetchDefaultBranch(at path: String) {
         // Check if origin remote exists first (fast, no network)
         guard run(args: ["remote", "get-url", "origin"], in: path) != nil else { return }
 

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -270,6 +270,7 @@ struct ContentView: View {
             appEnvironment.refresh()
             appEnvironment.refreshAllRepoInfo(projects: projects)
             appEnvironment.refreshPathValidity(projects: projects)
+            appEnvironment.fetchOrigin(projects: projects)
             updateChecker.check()
             // Apply saved appearance
             switch UserDefaults.standard.string(forKey: "factoryfloor.appearance") ?? "system" {
@@ -361,6 +362,7 @@ struct ContentView: View {
             appEnvironment.refreshAllRepoInfo(projects: projects)
             appEnvironment.refreshPathValidity(projects: projects)
             appEnvironment.refreshAllBranchPRs(projects: projects)
+            appEnvironment.fetchOrigin(projects: projects)
             syncWorkstreamNamesFromBranches()
         }
         .onReceive(Timer.publish(every: 6 * 60 * 60, on: .main, in: .common).autoconnect()) { _ in

--- a/Tests/GitOperationsTests.swift
+++ b/Tests/GitOperationsTests.swift
@@ -68,6 +68,90 @@ final class GitOperationsTests: XCTestCase {
         XCTAssertNil(GitOperations.mainRepositoryPath(for: subDir.path))
     }
 
+    // MARK: - defaultBranch
+
+    func testDefaultBranchReturnsLocalMainWhenNoRemote() throws {
+        let repoDir = tempDir.appendingPathComponent("no-remote")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init", "-b", "main"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        let branch = GitOperations.defaultBranch(at: repoDir.path)
+        XCTAssertEqual(branch, "main")
+    }
+
+    func testDefaultBranchReturnsMasterWhenNoMainBranch() throws {
+        let repoDir = tempDir.appendingPathComponent("master-repo")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init", "-b", "master"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        let branch = GitOperations.defaultBranch(at: repoDir.path)
+        XCTAssertEqual(branch, "master")
+    }
+
+    func testDefaultBranchReturnsHEADWhenNeitherMainNorMasterExist() throws {
+        let repoDir = tempDir.appendingPathComponent("custom-branch")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init", "-b", "develop"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        let branch = GitOperations.defaultBranch(at: repoDir.path)
+        XCTAssertEqual(branch, "HEAD")
+    }
+
+    func testDefaultBranchPrefersOriginOverLocal() throws {
+        // Create a non-bare "remote" repo with a commit on main
+        let remoteDir = tempDir.appendingPathComponent("remote")
+        try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
+        git(["init", "-b", "main"], in: remoteDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: remoteDir)
+
+        // Clone it so we have origin/main
+        let repoDir = tempDir.appendingPathComponent("cloned")
+        git(["clone", remoteDir.path, repoDir.path], in: tempDir)
+
+        let branch = GitOperations.defaultBranch(at: repoDir.path)
+        XCTAssertTrue(branch.contains("origin"), "Expected origin-prefixed branch, got: \(branch)")
+    }
+
+    // MARK: - fetchDefaultBranch
+
+    func testFetchDefaultBranchDoesNotCrashWithoutRemote() throws {
+        let repoDir = tempDir.appendingPathComponent("no-remote-fetch")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init", "-b", "main"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        // Should return silently without crashing
+        GitOperations.fetchDefaultBranch(at: repoDir.path)
+    }
+
+    func testFetchDefaultBranchDoesNotCrashForNonGitDirectory() throws {
+        let plainDir = tempDir.appendingPathComponent("not-a-repo")
+        try FileManager.default.createDirectory(at: plainDir, withIntermediateDirectories: true)
+
+        // Should return silently without crashing
+        GitOperations.fetchDefaultBranch(at: plainDir.path)
+    }
+
+    func testFetchDefaultBranchDoesNotCrashWithUnreachableRemote() throws {
+        let repoDir = tempDir.appendingPathComponent("bad-remote")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init", "-b", "main"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+        git(["remote", "add", "origin", "https://invalid.example.com/repo.git"], in: repoDir)
+
+        // Should fail silently (timeout or network error)
+        GitOperations.fetchDefaultBranch(at: repoDir.path)
+    }
+
     // MARK: - Helpers
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Adds periodic background fetch of origin's default branch per project (every 2 minutes), keeping `origin/main` fresh without blocking the UI
- Removes the blocking network fetch from `createWorktree`, making workstream creation instant
- Gracefully handles missing remotes, non-git directories, and network failures

## Test plan
- [x] 7 new tests for `defaultBranch` fallback chain and `fetchDefaultBranch` resilience
- [x] All 127 tests pass
- [ ] Manual: create workstream with network, verify it bases from fresh origin/main
- [ ] Manual: create workstream without network, verify it falls back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)