### PR TITLE
fix: differentiate merged vs open PRs and make badges clickable

### DIFF
--- a/Sources/Views/ProjectOverviewView.swift
+++ b/Sources/Views/ProjectOverviewView.swift
@@ -361,13 +361,16 @@ private struct WorktreeInfoRow: View {
                 if !worktree.isMain {
                     HStack(spacing: 8) {
                         if let pr {
-                            HStack(spacing: 3) {
-                                Image(systemName: "arrow.triangle.pull")
-                                    .font(.system(size: 10))
-                                Text(verbatim: "#\(pr.number)")
-                                    .font(.caption)
+                            let prColor: Color = pr.state == "MERGED" ? .purple : .green
+                            Link(destination: URL(string: pr.url)!) {
+                                HStack(spacing: 3) {
+                                    Image(systemName: pr.state == "MERGED" ? "arrow.triangle.merge" : "arrow.triangle.pull")
+                                        .font(.system(size: 10))
+                                    Text(verbatim: "#\(pr.number)")
+                                        .font(.caption)
+                                }
+                                .foregroundStyle(prColor)
                             }
-                            .foregroundStyle(.purple)
                         }
                         if worktree.isDirty {
                             HStack(spacing: 4) {


### PR DESCRIPTION
## Summary
- PR badges in the worktree list now show distinct icons and colors: green `arrow.triangle.pull` for open PRs, purple `arrow.triangle.merge` for merged PRs (matching the existing convention in WorkstreamInfoView)
- PR badges are now clickable links that open the PR in the browser

## Test plan
- [ ] Open the Info page for a project with worktrees that have open PRs — verify green badge with pull icon
- [ ] Check a worktree whose PR was merged — verify purple badge with merge icon
- [ ] Click a PR badge — verify it opens the correct GitHub PR URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)