### PR TITLE
fix: init ghostty submodule properly instead of symlinking entire directory

### DIFF
--- a/.hooks/worktree-create.sh
+++ b/.hooks/worktree-create.sh
@@ -1,25 +1,16 @@
 #!/usr/bin/env bash
 # ABOUTME: Claude Code worktree-create hook for Factory Floor.
-# ABOUTME: Symlinks build artifacts and runs a build so SourceKit resolves symbols.
+# ABOUTME: Initializes ghostty submodule, symlinks build artifacts, and runs a build so SourceKit resolves symbols.
 set -euo pipefail
 
 : "${WORKTREE_DIR:?WORKTREE_DIR must be set}"
 : "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR must be set}"
 
-# Ghostty xcframework (built with zig, not in git)
-XCFW_SRC="$CLAUDE_PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework"
-XCFW_DST="$WORKTREE_DIR/ghostty/macos/GhosttyKit.xcframework"
-
-if [ -d "$XCFW_SRC" ] && [ ! -e "$XCFW_DST" ]; then
-    ln -sfn "$XCFW_SRC" "$XCFW_DST"
-fi
-
-# Ghostty zig build output (resources, headers, etc.)
-ZIGOUT_SRC="$CLAUDE_PROJECT_DIR/ghostty/zig-out"
-ZIGOUT_DST="$WORKTREE_DIR/ghostty/zig-out"
-
-if [ -d "$ZIGOUT_SRC" ] && [ ! -e "$ZIGOUT_DST" ]; then
-    ln -sfn "$ZIGOUT_SRC" "$ZIGOUT_DST"
+# Ghostty submodule + build artifacts (built with zig, not in git)
+if [ -d "$CLAUDE_PROJECT_DIR/ghostty" ] && [ ! -e "$WORKTREE_DIR/ghostty/include" ]; then
+    git -C "$WORKTREE_DIR" -c protocol.file.allow=always submodule update --init --reference "$CLAUDE_PROJECT_DIR/ghostty" ghostty
+    ln -sfn "$CLAUDE_PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework" "$WORKTREE_DIR/ghostty/macos/GhosttyKit.xcframework"
+    ln -sfn "$CLAUDE_PROJECT_DIR/ghostty/zig-out" "$WORKTREE_DIR/ghostty/zig-out"
 fi
 
 # Build so SourceKit can resolve symbols across files in the worktree.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # ABOUTME: Workstream setup for Factory Floor development.
-# ABOUTME: Symlinks ghostty submodule from the main repo and runs a debug build.
+# ABOUTME: Initializes ghostty submodule, symlinks build artifacts, and runs a debug build.
 set -euo pipefail
 
 REPO_ROOT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
 
 # Ghostty submodule (headers + xcframework)
 if [ -d "$REPO_ROOT/ghostty" ] && [ ! -e ghostty/include ]; then
-    rm -rf ghostty
-    ln -sfn "$REPO_ROOT/ghostty" ghostty
-    echo "✓ Symlinked ghostty from main repo"
+    git -c protocol.file.allow=always submodule update --init --reference "$REPO_ROOT/ghostty" ghostty
+    ln -sfn "$REPO_ROOT/ghostty/macos/GhosttyKit.xcframework" ghostty/macos/GhosttyKit.xcframework
+    ln -sfn "$REPO_ROOT/ghostty/zig-out" ghostty/zig-out
+    echo "✓ Initialized ghostty submodule with local reference"
 fi
 
 # Pre-commit hooks


### PR DESCRIPTION
## Summary
- **`scripts/setup.sh`**: Replaced `rm -rf ghostty && ln -sfn` (whole-directory symlink) with `git submodule update --init --reference` to properly initialize the submodule, then symlink only the gitignored build artifacts
- **`.hooks/worktree-create.sh`**: Added submodule initialization before symlinking artifacts, so it works on fresh worktrees where `ghostty/` doesn't exist yet
- Both scripts use `-c protocol.file.allow=always` to handle git's default file transport restriction (CVE-2022-39253 mitigation since git 2.38.1)

Closes #322

## Test plan
- [ ] Create a new worktree via Claude Code and verify `git status` works without errors
- [ ] Create a new workstream via the IDE and verify `git status` works without errors
- [ ] Verify the build succeeds in both cases (xcframework and zig-out artifacts are accessible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)