### PR TITLE
fix: refresh git repo cache immediately on drag-drop

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -367,6 +367,8 @@ struct ContentView: View {
             projects.append(project)
             selection = .project(project.id)
             ProjectStore.save(projects)
+            appEnvironment.refreshPathValidity(projects: projects)
+            appEnvironment.refreshAllRepoInfo(projects: projects)
             logger.warning("[FF] projectCreated notification handled: \(project.name, privacy: .public)")
         }
         .onReceive(NotificationCenter.default.publisher(for: .purgeWorkstream)) { notification in


### PR DESCRIPTION
## Summary
- When dragging a git repo onto the sidebar, the "+" (add workstream) button wasn't available immediately because `gitRepoCache` wasn't populated until the next 15-second timer tick
- Now calls `refreshPathValidity` and `refreshAllRepoInfo` right after adding the project, so the cache is populated immediately

## Test plan
- [ ] Drag a git repo onto the sidebar
- [ ] Verify the "+" button appears immediately (not after a delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)