### PR TITLE
fix: re-sort sidebar projects on workstream activity

### DIFF
--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -326,6 +326,9 @@ struct ProjectSidebar: View {
             projects[pi].lastAccessedAt = now
             projects[pi].workstreams[wi].lastAccessedAt = now
             onProjectsChanged()
+            if sortOrder == .recent {
+                cachedSortedIDs = recomputeSortedIDs()
+            }
         }
         .onAppear {
             cachedSortedIDs = recomputeSortedIDs()


### PR DESCRIPTION
## Summary
- The sidebar's cached project sort order was only recomputed when the sort mode changed or a project was added/removed
- When a workstream received terminal activity, `lastAccessedAt` was updated but `cachedSortedIDs` was not refreshed, so projects stayed in stale order until the user toggled sort mode
- Now recomputes the sort cache after timestamp updates (only when sort is set to "recent")

## Test plan
- [ ] Open multiple projects, interact with workstreams in different projects
- [ ] Verify the most recently active project floats to the top in the sidebar
- [ ] Verify alphabetical sort is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)