### PR TITLE
feat: make run play icons clickable and style center start button

### DIFF
--- a/Sources/Views/EnvironmentTabView.swift
+++ b/Sources/Views/EnvironmentTabView.swift
@@ -149,9 +149,22 @@ struct EnvironmentTabView: View {
         let shortcut = "⌃⇧S"
         VStack(spacing: 0) {
             HStack {
-                Image(systemName: "play")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                if scriptConfig.run != nil, !runStarted {
+                    Button(action: {
+                        runStoppedManually = false
+                        runStarted = true
+                    }) {
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.borderless)
+                    .help(NSLocalizedString("Start", comment: ""))
+                } else {
+                    Image(systemName: "play")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
                 Text(title)
                     .font(.system(size: 12, weight: .semibold))
 
@@ -206,8 +219,17 @@ struct EnvironmentTabView: View {
                             runStoppedManually = false
                             runStarted = true
                         }) {
-                            Image(systemName: "play.fill")
-                                .font(.system(size: 24))
+                            HStack(spacing: 6) {
+                                Image(systemName: "play.fill")
+                                    .font(.system(size: 14))
+                                Text("Start")
+                                    .font(.system(size: 13, weight: .medium))
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.accentColor)
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
                         }
                         .buttonStyle(.borderless)
                         Text(script)


### PR DESCRIPTION
## Summary
- The play icon in the Environment tab toolbar header now acts as a button that starts the run script when clicked (when a run script exists and isn't already running)
- The center play button is restyled as a proper button with accent color background, "Start" label, and rounded corners

## Test plan
- [ ] Open a project with a run script configured
- [ ] Verify the play icon in the Run toolbar starts the script on click
- [ ] Verify the center "Start" button is visually styled as a button
- [ ] Verify clicking the center button starts the run script
- [ ] Verify projects without a run script still show the passive play icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)