### PR TITLE
feat: Cmd+Click opens links in external browser and fix HTTP redirects

### DIFF
--- a/Sources/Views/BrowserView.swift
+++ b/Sources/Views/BrowserView.swift
@@ -9,6 +9,14 @@ extension Notification.Name {
     static let browserTitleChanged = Notification.Name("factoryfloor.browserTitleChanged")
 }
 
+/// Hides the "Open Link in New Window" context menu item since the app is single-window.
+class BrowserWebView: WKWebView {
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        menu.items.removeAll { $0.identifier?.rawValue == "WKMenuItemIdentifierOpenLinkInNewWindow" }
+        super.willOpenMenu(menu, with: event)
+    }
+}
+
 func shouldRetargetBrowser(currentURL: String?, displayedURL: String, previousDefaultURL: String, nextDefaultURL: String, connectionError: Bool) -> Bool {
     guard normalizedBrowserURL(previousDefaultURL) != normalizedBrowserURL(nextDefaultURL) else {
         return false
@@ -284,7 +292,37 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
         }
 
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith _: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures _: WKWindowFeatures
+        ) -> WKWebView? {
+            // target="_blank" or JS window.open: load in the current view
+            if let url = navigationAction.request.url {
+                webView.load(URLRequest(url: url))
+            }
+            return nil
+        }
+
         // MARK: - WKNavigationDelegate
+
+        func webView(
+            _: WKWebView,
+            decidePolicyFor action: WKNavigationAction,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+        ) {
+            if action.navigationType == .linkActivated,
+               action.modifierFlags.contains(.command),
+               let url = action.request.url,
+               url.scheme == "https" || url.scheme == "http"
+            {
+                NSWorkspace.shared.open(url)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
             parent.isLoading = true

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -1360,7 +1360,7 @@ final class TerminalSurfaceCache: ObservableObject {
 
     func webView(for id: UUID) -> WKWebView {
         if let existing = webViews[id] { return existing }
-        let view = WKWebView()
+        let view = BrowserWebView()
         webViews[id] = view
         return view
     }

--- a/project.yml
+++ b/project.yml
@@ -46,6 +46,8 @@ targets:
         NSMainStoryboardFile: ""
         NSPrincipalClass: NSApplication
         LSUIElement: false
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoads: true
         SUPublicEDKey: "grC1rloxT0gFZ2mQVIuDTZlkNFXwXLZhn9+xs4YGuXo="
         SUFeedURL: https://factory-floor.com/appcast.xml
         SUEnableAutomaticChecks: true


### PR DESCRIPTION
## Summary
- **Cmd+Click** on links in the embedded browser opens them in the system default browser
- **HTTP redirects** now work (e.g. `http://www.ara.cat/` → `https://www.ara.cat/`) by enabling ATS arbitrary loads
- **target="_blank" links** load in the current view instead of silently failing
- **"Open Link in New Window"** context menu item removed (not applicable in single-window app)

## Test plan
- [ ] Cmd+Click a link in embedded browser → opens in system browser
- [ ] Type `http://www.ara.cat/` in address bar → redirects to https and loads
- [ ] Right-click a link → no "Open Link in New Window" item in context menu
- [ ] Click a `target="_blank"` link → loads in current browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)