### PR TITLE
feat: display agent-generated task descriptions in sidebar

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "Agent Teams" = "Equips d'agents";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Activa la coordinació experimental multi-agent. Els agents poden crear companys d'equip, delegar tasques i col·laborar entre fluxos de treball.";
 "Auto-rename branch" = "Canvia el nom de la branca automàticament";
-"The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "L'agent canviarà el nom de la branca de l'arbre de treball per coincidir amb la tasca a la primera sol·licitud (p. ex., fix-login-timeout).";
+"On the first request, the agent renames the branch to match the task and writes a short description visible in the sidebar." = "A la primera sol·licitud, l'agent canvia el nom de la branca per coincidir amb la tasca i escriu una breu descripció visible a la barra lateral.";
 "External Browser" = "Navegador extern";
 
 /* Settings - Advanced */

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "Agent Teams" = "Agent Teams";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams.";
 "Auto-rename branch" = "Auto-rename branch";
-"The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout).";
+"On the first request, the agent renames the branch to match the task and writes a short description visible in the sidebar." = "On the first request, the agent renames the branch to match the task and writes a short description visible in the sidebar.";
 "External Browser" = "External Browser";
 
 /* Settings - Advanced */

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "Agent Teams" = "Equipos de agentes";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Activa la coordinación experimental multi-agente. Los agentes pueden crear compañeros, delegar tareas y colaborar entre flujos de trabajo.";
 "Auto-rename branch" = "Renombrar rama automáticamente";
-"The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "El agente renombrará la rama del árbol de trabajo para coincidir con la tarea en la primera solicitud (p. ej., fix-login-timeout).";
+"On the first request, the agent renames the branch to match the task and writes a short description visible in the sidebar." = "En la primera solicitud, el agente renombra la rama para coincidir con la tarea y escribe una breve descripción visible en la barra lateral.";
 "External Browser" = "Navegador externo";
 
 /* Settings - Advanced */

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "Agent Teams" = "Agentteam";
 "Enables experimental multi-agent coordination. Agents can spawn teammates, delegate tasks, and collaborate across workstreams." = "Aktiverar experimentell multi-agentkoordinering. Agenter kan skapa teammedlemmar, delegera uppgifter och samarbeta mellan arbetsflöden.";
 "Auto-rename branch" = "Byt namn på gren automatiskt";
-"The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)." = "Agenten byter namn på arbetsträdsgrenen för att matcha uppgiften vid den första förfrågan (t.ex. fix-login-timeout).";
+"On the first request, the agent renames the branch to match the task and writes a short description visible in the sidebar." = "Vid den första förfrågan byter agenten namn på grenen för att matcha uppgiften och skriver en kort beskrivning synlig i sidofältet.";
 "External Browser" = "Extern webbläsare";
 
 /* Settings - Advanced */

--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -39,6 +39,9 @@ final class AppEnvironment: ObservableObject {
     /// Active port cache per workstream ID
     @Published private var activePortCache: Set<UUID> = []
 
+    /// Task description cache per worktree path
+    @Published private var taskDescriptionCache: [String: String] = [:]
+
     /// GitHub remote detection cache per project directory (lightweight git check)
     @Published private var githubRemoteCache: [String: Bool] = [:]
 
@@ -191,6 +194,11 @@ final class AppEnvironment: ObservableObject {
         activePortCache.contains(workstreamID)
     }
 
+    func taskDescription(for worktreePath: String?) -> String? {
+        guard let path = worktreePath else { return nil }
+        return taskDescriptionCache[path]
+    }
+
     /// Returns IDs of projects whose directories no longer exist.
     @Published var missingProjectIDs: Set<UUID> = []
 
@@ -201,6 +209,7 @@ final class AppEnvironment: ObservableObject {
             var gitRepoResults: [String: Bool] = [:]
             var githubRemoteResults: [String: Bool] = [:]
             var portResults: Set<UUID> = []
+            var descriptionResults: [String: String] = [:]
 
             // Collect valid worktree paths that need git info
             var validPaths: [String] = []
@@ -220,13 +229,22 @@ final class AppEnvironment: ObservableObject {
                     if RunStateStore.loadValidated(for: ws.id)?.detectedPorts.isEmpty == false {
                         portResults.insert(ws.id)
                     }
-
                     guard let path = ws.worktreePath else { continue }
                     var wsIsDir: ObjCBool = false
                     let valid = FileManager.default.fileExists(atPath: path, isDirectory: &wsIsDir) && wsIsDir.boolValue
                     results[path] = valid
                     if valid {
                         validPaths.append(path)
+                        let descURL = URL(fileURLWithPath: path)
+                            .appendingPathComponent(".factoryfloor-state/description")
+                        if let data = try? Data(contentsOf: descURL),
+                           let text = String(data: data, encoding: .utf8)
+                        {
+                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !trimmed.isEmpty {
+                                descriptionResults[path] = trimmed
+                            }
+                        }
                     }
                 }
             }
@@ -290,6 +308,7 @@ final class AppEnvironment: ObservableObject {
                 self.githubRemoteCache.merge(githubRemoteResults) { _, new in new }
                 self.worktreeStateCache.merge(worktreeStates) { _, new in new }
                 self.activePortCache = portResults
+                self.taskDescriptionCache = descriptionResults
             }
         }
     }

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -130,6 +130,8 @@ enum GitOperations {
             symlinkEnvFiles(from: projectPath, to: worktreeDir.path)
         }
 
+        addExcludeEntry(at: projectPath, pattern: ".factoryfloor-state/")
+
         return worktreeDir.path
     }
 
@@ -150,6 +152,29 @@ enum GitOperations {
             }
             guard !fm.fileExists(atPath: destination.path) else { continue }
             try? fm.createSymbolicLink(at: destination, withDestinationURL: source)
+        }
+    }
+
+    /// Append a pattern to .git/info/exclude if not already present.
+    private static func addExcludeEntry(at repoPath: String, pattern: String) {
+        let excludeURL = URL(fileURLWithPath: repoPath).appendingPathComponent(".git/info/exclude")
+        let fm = FileManager.default
+
+        // Ensure the info directory exists
+        let infoDir = excludeURL.deletingLastPathComponent()
+        try? fm.createDirectory(at: infoDir, withIntermediateDirectories: true)
+
+        let existing = (try? String(contentsOf: excludeURL, encoding: .utf8)) ?? ""
+        let lines = existing.components(separatedBy: .newlines)
+        if lines.contains(pattern) { return }
+
+        let entry = existing.hasSuffix("\n") || existing.isEmpty ? pattern + "\n" : "\n" + pattern + "\n"
+        if let data = entry.data(using: .utf8), let handle = try? FileHandle(forWritingTo: excludeURL) {
+            handle.seekToEndOfFile()
+            handle.write(data)
+            handle.closeFile()
+        } else {
+            try? (existing + entry).write(to: excludeURL, atomically: true, encoding: .utf8)
         }
     }
 

--- a/Sources/Models/SystemPrompts.swift
+++ b/Sources/Models/SystemPrompts.swift
@@ -5,14 +5,19 @@ import Foundation
 
 enum SystemPrompts {
     static let autoRenameBranchPrompt = """
-        When the user presents their first request: \
-        1) Generate a short descriptive git branch name summarizing the task. \
-        2) Rename the current branch using `git branch -m <new-name>`. \
-        3) Keep the existing branch prefix (everything before the last `/`). \
-        4) Use kebab-case and keep the descriptive part under 6 words. \
-        5) After renaming, continue with the task normally. \
-        If the branch already has a meaningful descriptive name (not a random generated name), do nothing. \
-        Example: if the branch is `ff/scan-deep-thr` and the user asks to "fix the login timeout bug", \
-        rename it to `ff/fix-login-timeout-bug`.
-        """
+    You are working inside Factory Floor, a Mac app that runs coding agents in parallel worktrees. \
+    When the user presents their first request: \
+    1) Generate a short descriptive git branch name summarizing the task. \
+    Use concrete, specific language. Avoid abstract nouns. \
+    2) Rename the current branch using `git branch -m <new-name>`. \
+    3) Keep the existing branch prefix (everything before the last `/`). \
+    4) Use kebab-case and keep the descriptive part under 6 words. \
+    5) Write a one-sentence task description: \
+    `mkdir -p .factoryfloor-state && echo "your description" > .factoryfloor-state/description` \
+    6) After renaming and writing the description, continue with the task normally. \
+    If the branch already has a meaningful descriptive name (not a random generated name), \
+    skip the rename but still write the description if `.factoryfloor-state/description` does not exist. \
+    Example: if the branch is `ff/scan-deep-thr` and the user asks to "fix the login timeout bug", \
+    rename it to `ff/fix-login-timeout-bug` and write "Fix login timeout by increasing session TTL" to the description file.
+    """
 }

--- a/Sources/Models/WorkstreamEnvironment.swift
+++ b/Sources/Models/WorkstreamEnvironment.swift
@@ -6,6 +6,7 @@ import Foundation
 enum WorkstreamEnvironment {
     /// Build the environment variables for a workstream's terminal sessions.
     static func variables(
+        workstreamID: UUID,
         projectName: String,
         workstreamName: String,
         projectDirectory: String,
@@ -14,6 +15,7 @@ enum WorkstreamEnvironment {
         agentTeams: Bool
     ) -> [String: String] {
         var vars = [
+            "FF_WORKSTREAM_ID": workstreamID.uuidString.lowercased(),
             "FF_PROJECT": projectName,
             "FF_WORKSTREAM": workstreamName,
             "FF_PROJECT_DIR": projectDirectory,

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -107,6 +107,7 @@ struct ProjectSidebar: View {
                         isPathValid: appEnv.isPathValid(workstream.worktreePath),
                         hasActivePort: appEnv.hasActivePort(workstream.id),
                         githubURL: appEnv.githubURL(for: project.directory),
+                        taskDescription: appEnv.taskDescription(for: workstream.worktreePath),
                         prTitle: pr?.title,
                         prNumber: pr?.number,
                         prState: pr?.state,
@@ -721,6 +722,7 @@ private struct WorkstreamRow: View {
     let isPathValid: Bool
     var hasActivePort: Bool = false
     var githubURL: URL?
+    var taskDescription: String?
     var prTitle: String?
     var prNumber: Int?
     var prState: String?
@@ -735,6 +737,9 @@ private struct WorkstreamRow: View {
         guard isPathValid else { return nil }
         if let prTitle, let prNumber {
             return "\(prTitle) #\(prNumber)"
+        }
+        if let taskDescription {
+            return taskDescription
         }
         if let branchName, branchName != name {
             return branchName

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -198,7 +198,7 @@ struct SettingsView: View {
                 SettingToggle(
                     "Auto-rename branch",
                     isOn: $autoRenameBranch,
-                    description: "The agent will rename the worktree branch to match the task on the first request (e.g., fix-login-timeout)."
+                    description: "On the first request, the agent renames the branch to match the task and writes a short description visible in the sidebar."
                 )
 
                 SettingToggle(

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -783,6 +783,7 @@ struct TerminalContainerView: View {
 
     private var envVars: [String: String] {
         WorkstreamEnvironment.variables(
+            workstreamID: workstreamID,
             projectName: projectName,
             workstreamName: workstreamName,
             projectDirectory: projectDirectory,


### PR DESCRIPTION
## Summary
- Agent writes a one-sentence task description to `.factoryfloor-state/description` in the worktree on first request
- App reads it during its 15s refresh cycle and displays it in the sidebar (priority: PR title > task description > branch name)
- `.factoryfloor-state/` is excluded via `.git/info/exclude` on worktree creation (never committed)
- Injects `FF_WORKSTREAM_ID` env var into terminal sessions
- Improves branch naming guidance and tells the agent it's running inside Factory Floor

## Related issues
- Created #332 (inject target/base branch into prompt)
- Created #333 (suggest new workspaces for parallel tasks)
- Created #335 (move run-state into .factoryfloor-state/)

## Test plan
- [ ] Build and run the app
- [ ] Create a workstream, verify `.factoryfloor-state/` is in `.git/info/exclude`
- [ ] Manually write a description file: `mkdir -p .factoryfloor-state && echo "Test description" > .factoryfloor-state/description`
- [ ] Wait ~15s, verify description appears in sidebar below workstream name
- [ ] Start a coding agent with auto-rename enabled, verify it writes the description
- [ ] Verify PR title still takes priority over description when a PR exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)