### PR TITLE
feat: show task description in workstream title subtitle

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -96,7 +96,7 @@ struct ContentView: View {
                 )
                 .id(workstream.id)
                 .navigationTitle(workstream.name)
-                .navigationSubtitle(project.name)
+                .navigationSubtitle(appEnvironment.taskDescription(for: workstream.worktreePath) ?? project.name)
             } else {
                 VStack(spacing: 12) {
                     ProgressView()
@@ -106,7 +106,7 @@ struct ContentView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .navigationTitle(workstream.name)
-                .navigationSubtitle(project.name)
+                .navigationSubtitle(appEnvironment.taskDescription(for: workstream.worktreePath) ?? project.name)
             }
         } else if let project = activeProject,
                   let projectIndex = projects.firstIndex(where: { $0.id == project.id })

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -225,10 +225,11 @@ struct TerminalContainerView: View {
     }
 
     private var portSubtitle: String {
+        let label = appEnv.taskDescription(for: workingDirectory) ?? projectName
         if let port = portDetector.selectedPort {
-            return "localhost:\(port) · \u{2318}B for browser"
+            return "\(label) · localhost:\(port) · \u{2318}B for browser"
         }
-        return projectName
+        return label
     }
 
     private var browserDefaultURL: String {


### PR DESCRIPTION
## Summary
- Display agent-generated task descriptions in the navigation subtitle when available, falling back to the project name
- Combine task description with port info when both exist (e.g. `description · localhost:3000 · ⌘B for browser`)

## Test plan
- [ ] Open a workstream with a task description — verify subtitle shows description instead of project name
- [ ] Open a workstream with a running port — verify subtitle shows `description · localhost:port · ⌘B for browser`
- [ ] Open a workstream without a task description — verify subtitle falls back to project name

🤖 Generated with [Claude Code](https://claude.com/claude-code)