### PR TITLE
chore: ignore dirty state in ghostty submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ghostty"]
 	path = ghostty
 	url = https://github.com/ghostty-org/ghostty.git
+	ignore = dirty


### PR DESCRIPTION
## Summary
- Add `ignore = dirty` to ghostty submodule in `.gitmodules`
- Suppresses "untracked content" noise from `zig-out/` build artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)