### PR TITLE
fix: enable Option+Backspace word deletion in terminal

### DIFF
--- a/Sources/Terminal/TerminalApp.swift
+++ b/Sources/Terminal/TerminalApp.swift
@@ -184,6 +184,15 @@ final class TerminalApp {
             return
         }
         ghostty_config_load_default_files(config)
+
+        // Enable left Option as Alt so Option+Backspace deletes words in terminal
+        let appConfigStr = "macos-option-as-alt = left\n"
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("factoryfloor-ghostty.conf")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data(appConfigStr.utf8))
+        ghostty_config_load_file(config, tmpFile.path)
+        try? FileManager.default.removeItem(at: tmpFile)
+
         ghostty_config_finalize(config)
 
         // Create runtime config with callbacks

--- a/Sources/Terminal/TerminalView.swift
+++ b/Sources/Terminal/TerminalView.swift
@@ -251,26 +251,63 @@ final class TerminalView: NSView {
     // MARK: - Keyboard
 
     override func keyDown(with event: NSEvent) {
-        guard surface != nil else {
+        guard let surface else {
             interpretKeyEvents([event])
             return
         }
 
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
+        // Ask Ghostty for translated modifiers (handles macos-option-as-alt config).
+        // When option-as-alt is enabled, this strips .option so interpretKeyEvents
+        // produces the base character instead of a composed one (e.g., Option+Backspace
+        // sends ESC+DEL instead of a special character).
+        let translationModsGhostty = Self.ghosttyModsToFlags(
+            ghostty_surface_key_translation_mods(
+                surface,
+                Self.flagsToGhosttyMods(event.modifierFlags)
+            )
+        )
+
+        let translationEvent: NSEvent
+        if translationModsGhostty == event.modifierFlags.intersection([.shift, .control, .option, .command]) {
+            translationEvent = event
+        } else {
+            var translationMods = event.modifierFlags
+            for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
+                if translationModsGhostty.contains(flag) {
+                    translationMods.insert(flag)
+                } else {
+                    translationMods.remove(flag)
+                }
+            }
+            translationEvent = NSEvent.keyEvent(
+                with: event.type,
+                location: event.locationInWindow,
+                modifierFlags: translationMods,
+                timestamp: event.timestamp,
+                windowNumber: event.windowNumber,
+                context: nil,
+                characters: event.characters(byApplyingModifiers: translationMods) ?? "",
+                charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+                isARepeat: event.isARepeat,
+                keyCode: event.keyCode
+            ) ?? event
+        }
+
         // Use interpretKeyEvents to handle text composition (IME, dead keys, etc).
         // keyTextAccumulator collects text produced by insertText calls during this.
         keyTextAccumulator = []
         defer { keyTextAccumulator = nil }
 
-        interpretKeyEvents([event])
+        interpretKeyEvents([translationEvent])
 
         if let textList = keyTextAccumulator, !textList.isEmpty {
             for text in textList {
                 _ = sendKeyEvent(action, event: event, text: text)
             }
         } else {
-            let text = Self.ghosttyCharacters(for: event)
+            let text = Self.ghosttyCharacters(for: translationEvent)
             _ = sendKeyEvent(action, event: event, text: text)
         }
 
@@ -560,7 +597,25 @@ final class TerminalView: NSView {
         if flags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
         if flags.contains(.command) { mods |= GHOSTTY_MODS_SUPER.rawValue }
         if flags.contains(.capsLock) { mods |= GHOSTTY_MODS_CAPS.rawValue }
+
+        // Sided modifier detection for option-as-alt left/right distinction
+        let rawFlags = flags.rawValue
+        if rawFlags & UInt(NX_DEVICERSHIFTKEYMASK) != 0 { mods |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue }
+        if rawFlags & UInt(NX_DEVICERCTLKEYMASK) != 0 { mods |= GHOSTTY_MODS_CTRL_RIGHT.rawValue }
+        if rawFlags & UInt(NX_DEVICERALTKEYMASK) != 0 { mods |= GHOSTTY_MODS_ALT_RIGHT.rawValue }
+        if rawFlags & UInt(NX_DEVICERCMDKEYMASK) != 0 { mods |= GHOSTTY_MODS_SUPER_RIGHT.rawValue }
+
         return ghostty_input_mods_e(rawValue: mods)
+    }
+
+    /// Convert ghostty mods back to NSEvent.ModifierFlags.
+    private static func ghosttyModsToFlags(_ mods: ghostty_input_mods_e) -> NSEvent.ModifierFlags {
+        var flags = NSEvent.ModifierFlags(rawValue: 0)
+        if mods.rawValue & GHOSTTY_MODS_SHIFT.rawValue != 0 { flags.insert(.shift) }
+        if mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0 { flags.insert(.control) }
+        if mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0 { flags.insert(.option) }
+        if mods.rawValue & GHOSTTY_MODS_SUPER.rawValue != 0 { flags.insert(.command) }
+        return flags
     }
 }
 


### PR DESCRIPTION
## Summary

- **Option+Backspace** (delete word) doesn't work in Factory Floor's embedded terminal — it produces a composed special character instead of sending ESC+DEL
- Configures Ghostty's `macos-option-as-alt = left` so the **left Option** key acts as Alt/Meta
- **Right Option** remains the macOS compose key for accented characters (ñ, ü, etc.)
- Adds proper modifier translation in `keyDown` using Ghostty's `ghostty_surface_key_translation_mods` API, so `interpretKeyEvents` sees the base character
- Adds sided modifier detection (`NX_DEVICE*` masks) to distinguish left vs right Option

## Changes

- `TerminalApp.swift`: Loads `macos-option-as-alt = left` config into Ghostty at init
- `TerminalView.swift`: Translates modifier flags before `interpretKeyEvents` using Ghostty's translation API; adds sided modifier detection and `ghosttyModsToFlags` reverse helper

## Test plan

- [ ] Open a terminal tab and press **Option+Backspace** — should delete the previous word
- [ ] Press **Option+Left/Right arrow** — should jump word-by-word
- [ ] Press **Right Option+e, then a** — should produce `á` (compose key still works)
- [ ] Press **Right Option+n, then n** — should produce `ñ`
- [ ] Verify IME / dead key input (e.g., Japanese, Korean) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)