### PR TITLE
feat: show workstream description tooltip on sidebar hover

### DIFF
--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -790,6 +790,7 @@ private struct WorkstreamRow: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
+        .help(taskDescription ?? "")
         .onHover { isHovering = $0 }
         .contextMenu {
             if let worktreePath {


### PR DESCRIPTION
## Summary
- Adds a native macOS tooltip (`.help()`) to workstream rows in the sidebar
- When a workstream has a task description, hovering shows the full text

## Test plan
- [ ] Hover over a workstream with a description — tooltip appears
- [ ] Hover over a workstream without a description — no tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)