### PR TITLE
feat: restrict agent filesystem writes to worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,20 @@ via FSEvents and retargets the embedded browser when a port is detected.
 - URL scheme: `factoryfloor://`
 - Bundle ID: `com.alltuner.factoryfloor`
 
+### System prompts
+
+The Coding Agent receives additional system prompts via `--append-system-prompt` based on
+user settings. Prompts are defined in `Sources/Models/SystemPrompts.swift` and assembled in
+`TerminalContainerView.buildClaudeCommand()`.
+
+**Important**: Claude Code only accepts a single `--append-system-prompt` flag per invocation.
+Multiple flags do not stack; the last one wins. When multiple prompts are active, they must be
+concatenated into a single string before passing to the CLI.
+
+Active prompts (combined when multiple are enabled):
+- **Restrict to worktree** (default: on, setting: `factoryfloor.allowOutsideWorktree`): constrains file writes to the worktree directory.
+- **Auto-rename branch** (setting: `factoryfloor.autoRenameBranch`): renames the git branch to match the task on first request.
+
 ## Localization
 
 All user-facing strings MUST use localization. Never hardcode strings directly in SwiftUI views or code.

--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "Coding Agent" = "Agent de codi";
 "Bypass permission prompts" = "Ometre les sol·licituds de permisos";
 "When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking." = "Quan està activat, l'agent de codi no demanarà confirmació abans de fer canvis. Utilitza amb precaució: l'agent podrà editar fitxers, executar ordres i fer commits sense preguntar.";
+"Allow writes outside worktree" = "Permetre escriptures fora del worktree";
+"When enabled, the coding agent can modify files anywhere on disk. When disabled, writes are restricted to the worktree directory." = "Quan està activat, l'agent de codi pot modificar fitxers a qualsevol lloc del disc. Quan està desactivat, les escriptures es restringeixen al directori del worktree.";
 "External Terminal" = "Terminal extern";
 "Requires tmux to be installed." = "Requereix tmux instal·lat.";
 "URL" = "URL";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "Coding Agent" = "Coding Agent";
 "Bypass permission prompts" = "Bypass permission prompts";
 "When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking." = "When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking.";
+"Allow writes outside worktree" = "Allow writes outside worktree";
+"When enabled, the coding agent can modify files anywhere on disk. When disabled, writes are restricted to the worktree directory." = "When enabled, the coding agent can modify files anywhere on disk. When disabled, writes are restricted to the worktree directory.";
 "External Terminal" = "External Terminal";
 "Requires tmux to be installed." = "Requires tmux to be installed.";
 "URL" = "URL";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "Coding Agent" = "Agente de código";
 "Bypass permission prompts" = "Omitir solicitudes de permisos";
 "When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking." = "Cuando está activado, el agente de código no pedirá confirmación antes de hacer cambios. Úsalo con precaución: el agente podrá editar archivos, ejecutar comandos y hacer commits sin preguntar.";
+"Allow writes outside worktree" = "Permitir escrituras fuera del worktree";
+"When enabled, the coding agent can modify files anywhere on disk. When disabled, writes are restricted to the worktree directory." = "Cuando está activado, el agente de código puede modificar archivos en cualquier lugar del disco. Cuando está desactivado, las escrituras se restringen al directorio del worktree.";
 "External Terminal" = "Terminal externa";
 "Requires tmux to be installed." = "Requiere tmux instalado.";
 "URL" = "URL";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "Coding Agent" = "Kodningsagent";
 "Bypass permission prompts" = "Hoppa över behörighetsförfrågningar";
 "When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking." = "När aktiverad kommer kodningsagenten inte att be om bekräftelse innan ändringar görs. Använd med försiktighet: agenten kan redigera filer, köra kommandon och göra commits utan att fråga.";
+"Allow writes outside worktree" = "Tillåt skrivningar utanför worktree";
+"When enabled, the coding agent can modify files anywhere on disk. When disabled, writes are restricted to the worktree directory." = "När aktiverad kan kodningsagenten ändra filer var som helst på disken. När inaktiverad begränsas skrivningar till worktree-katalogen.";
 "External Terminal" = "Extern terminal";
 "Requires tmux to be installed." = "Kräver att tmux är installerat.";
 "URL" = "URL";

--- a/Sources/Models/LaunchLogger.swift
+++ b/Sources/Models/LaunchLogger.swift
@@ -15,6 +15,7 @@ struct LaunchLogEntry: Codable {
         let bypassPermissions: Bool
         let agentTeams: Bool
         let autoRenameBranch: Bool
+        let allowOutsideWorktree: Bool
     }
 
     let timestamp: String

--- a/Sources/Models/SystemPrompts.swift
+++ b/Sources/Models/SystemPrompts.swift
@@ -4,6 +4,17 @@
 import Foundation
 
 enum SystemPrompts {
+    static func restrictToWorktreePrompt(worktreePath: String) -> String {
+        """
+        CRITICAL FILESYSTEM CONSTRAINT: You MUST NOT create, edit, delete, or modify any files \
+        outside of the following directory: \(worktreePath)
+        This includes temporary files, configuration files, and any other filesystem writes. \
+        All file operations MUST target paths within \(worktreePath). \
+        If a task requires modifying files outside this path, explain what needs to change and \
+        ask the user to do it manually or to enable unrestricted filesystem access in Settings.
+        """
+    }
+
     static let autoRenameBranchPrompt = """
     You are working inside Factory Floor, a Mac app that runs coding agents in parallel worktrees. \
     When the user presents their first request: \

--- a/Sources/Views/EnvironmentTabView.swift
+++ b/Sources/Views/EnvironmentTabView.swift
@@ -333,7 +333,8 @@ struct EnvironmentTabView: View {
                 tmuxMode: useTmux,
                 bypassPermissions: false,
                 agentTeams: false,
-                autoRenameBranch: false
+                autoRenameBranch: false,
+                allowOutsideWorktree: false
             ),
             shell: CommandBuilder.userShell
         ))

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @AppStorage("factoryfloor.languageOverride") private var languageOverride: String = ""
     @AppStorage("factoryfloor.tmuxMode") private var tmuxMode: Bool = false
     @AppStorage("factoryfloor.bypassPermissions") private var bypassPermissions: Bool = false
+    @AppStorage("factoryfloor.allowOutsideWorktree") private var allowOutsideWorktree: Bool = false
     @AppStorage("factoryfloor.agentTeams") private var agentTeams: Bool = false
     @AppStorage("factoryfloor.autoRenameBranch") private var autoRenameBranch: Bool = false
     @AppStorage("factoryfloor.defaultTerminal") private var defaultTerminal: String = ""
@@ -187,6 +188,13 @@ struct SettingsView: View {
                     isOn: $bypassPermissions,
                     description: "When enabled, the coding agent will not ask for confirmation before making changes. Use with caution: the agent will be able to edit files, run commands, and make git commits without asking.",
                     descriptionStyle: bypassPermissions ? .warning : .secondary
+                )
+
+                SettingToggle(
+                    "Allow writes outside worktree",
+                    isOn: $allowOutsideWorktree,
+                    description: "When enabled, the coding agent can modify files anywhere on disk. When disabled, writes are restricted to the worktree directory.",
+                    descriptionStyle: allowOutsideWorktree ? .warning : .secondary
                 )
 
                 SettingToggle(

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -166,6 +166,7 @@ struct TerminalContainerView: View {
     @AppStorage("factoryfloor.tmuxMode") private var tmuxMode: Bool = false
     @AppStorage("factoryfloor.agentTeams") private var agentTeams: Bool = false
     @AppStorage("factoryfloor.autoRenameBranch") private var autoRenameBranch: Bool = false
+    @AppStorage("factoryfloor.allowOutsideWorktree") private var allowOutsideWorktree: Bool = false
     @AppStorage("factoryfloor.quickActionDebug") private var quickActionDebug: Bool = false
     @State private var activeTab: WorkspaceTab = .info
     @State private var tabs: [WorkspaceTab] = [.info, .agent]
@@ -246,6 +247,15 @@ struct TerminalContainerView: View {
         guard let basePath = appEnv.toolStatus.claude.path else { return nil }
         let sessionID = workstreamID.uuidString.lowercased()
 
+        var systemPromptParts: [String] = []
+        if !allowOutsideWorktree {
+            systemPromptParts.append(SystemPrompts.restrictToWorktreePrompt(worktreePath: workingDirectory))
+        }
+        if autoRenameBranch {
+            systemPromptParts.append(SystemPrompts.autoRenameBranchPrompt)
+        }
+        let combinedSystemPrompt = systemPromptParts.isEmpty ? nil : systemPromptParts.joined(separator: "\n\n")
+
         var resume = CommandBuilder(basePath)
         resume.option("--resume", sessionID)
         if appEnv.toolStatus.claudeSupportsSessionName {
@@ -253,8 +263,8 @@ struct TerminalContainerView: View {
         }
         if useTmux { resume.flag("--teammate-mode"); resume.arg("tmux") }
         if bypassPermissions { resume.flag("--dangerously-skip-permissions") }
-        if autoRenameBranch {
-            resume.option("--append-system-prompt", SystemPrompts.autoRenameBranchPrompt)
+        if let combinedSystemPrompt {
+            resume.option("--append-system-prompt", combinedSystemPrompt)
         }
 
         var fresh = CommandBuilder(basePath)
@@ -264,8 +274,8 @@ struct TerminalContainerView: View {
         }
         if useTmux { fresh.flag("--teammate-mode"); fresh.arg("tmux") }
         if bypassPermissions { fresh.flag("--dangerously-skip-permissions") }
-        if autoRenameBranch {
-            fresh.option("--append-system-prompt", SystemPrompts.autoRenameBranchPrompt)
+        if let combinedSystemPrompt {
+            fresh.option("--append-system-prompt", combinedSystemPrompt)
         }
 
         let cmd = CommandBuilder.withFallback(
@@ -299,12 +309,17 @@ struct TerminalContainerView: View {
                 tmuxMode: tmuxMode,
                 bypassPermissions: bypassPermissions,
                 agentTeams: agentTeams,
-                autoRenameBranch: autoRenameBranch
+                autoRenameBranch: autoRenameBranch,
+                allowOutsideWorktree: allowOutsideWorktree
             ),
             shell: CommandBuilder.userShell
         ))
 
         return finalCommand
+    }
+
+    private func rebuildClaudeCommand() {
+        cachedClaudeCommand = buildClaudeCommand()
     }
 
     private var fixedTabs: [WorkspaceTab] {
@@ -456,6 +471,29 @@ struct TerminalContainerView: View {
     }
 
     private var mainContent: some View {
+        mainLayout
+            .onChange(of: tmuxMode) { rebuildClaudeCommand() }
+            .onChange(of: bypassPermissions) { rebuildClaudeCommand() }
+            .onChange(of: autoRenameBranch) { rebuildClaudeCommand() }
+            .onChange(of: allowOutsideWorktree) { rebuildClaudeCommand() }
+            .onChange(of: workstreamName) { rebuildClaudeCommand() }
+            .onChange(of: appEnv.isDetecting) {
+                rebuildClaudeCommand()
+                preloadSurfaces()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .toggleInfo)) { _ in activeTab = .info }
+            .onReceive(NotificationCenter.default.publisher(for: .focusAgent)) { _ in activeTab = .agent }
+            .onReceive(NotificationCenter.default.publisher(for: .toggleEnvironment)) { _ in
+                if tabs.contains(.environment) { activeTab = .environment }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .toggleTerminal)) { _ in addTerminal() }
+            .onReceive(NotificationCenter.default.publisher(for: .toggleBrowser)) { _ in addBrowser() }
+            .onReceive(NotificationCenter.default.publisher(for: .closeTerminal)) { _ in
+                if activeTab.isCloseable { closeTab(activeTab) }
+            }
+    }
+
+    private var mainLayout: some View {
         VStack(spacing: 0) {
             tabBar
             Divider()
@@ -511,24 +549,6 @@ struct TerminalContainerView: View {
         .onReceive(NotificationCenter.default.publisher(for: .terminalActivity)) { notification in
             guard let wsID = notification.object as? UUID, wsID == workstreamID else { return }
             appEnv.refreshWorktreeState(for: workingDirectory, projectDirectory: projectDirectory)
-        }
-        .onChange(of: tmuxMode) { cachedClaudeCommand = buildClaudeCommand() }
-        .onChange(of: bypassPermissions) { cachedClaudeCommand = buildClaudeCommand() }
-        .onChange(of: autoRenameBranch) { cachedClaudeCommand = buildClaudeCommand() }
-        .onChange(of: workstreamName) { cachedClaudeCommand = buildClaudeCommand() }
-        .onChange(of: appEnv.isDetecting) {
-            cachedClaudeCommand = buildClaudeCommand()
-            preloadSurfaces()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .toggleInfo)) { _ in activeTab = .info }
-        .onReceive(NotificationCenter.default.publisher(for: .focusAgent)) { _ in activeTab = .agent }
-        .onReceive(NotificationCenter.default.publisher(for: .toggleEnvironment)) { _ in
-            if tabs.contains(.environment) { activeTab = .environment }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .toggleTerminal)) { _ in addTerminal() }
-        .onReceive(NotificationCenter.default.publisher(for: .toggleBrowser)) { _ in addBrowser() }
-        .onReceive(NotificationCenter.default.publisher(for: .closeTerminal)) { _ in
-            if activeTab.isCloseable { closeTab(activeTab) }
         }
     }
 

--- a/Tests/LaunchLoggerTests.swift
+++ b/Tests/LaunchLoggerTests.swift
@@ -34,7 +34,7 @@ final class LaunchLoggerTests: XCTestCase {
             environmentVariables: ["FF_PROJECT": "myproject"],
             workingDirectory: "/tmp/test",
             toolPaths: LaunchLogEntry.ToolPaths(claude: "/usr/local/bin/claude", tmux: "/usr/bin/tmux", ffRun: nil),
-            settings: LaunchLogEntry.Settings(tmuxMode: true, bypassPermissions: false, agentTeams: false, autoRenameBranch: true),
+            settings: LaunchLogEntry.Settings(tmuxMode: true, bypassPermissions: false, agentTeams: false, autoRenameBranch: true, allowOutsideWorktree: false),
             shell: "/bin/zsh"
         )
 
@@ -128,7 +128,7 @@ final class LaunchLoggerTests: XCTestCase {
             environmentVariables: [:],
             workingDirectory: "/tmp",
             toolPaths: LaunchLogEntry.ToolPaths(claude: nil, tmux: nil, ffRun: nil),
-            settings: LaunchLogEntry.Settings(tmuxMode: false, bypassPermissions: false, agentTeams: false, autoRenameBranch: false),
+            settings: LaunchLogEntry.Settings(tmuxMode: false, bypassPermissions: false, agentTeams: false, autoRenameBranch: false, allowOutsideWorktree: false),
             shell: "/bin/zsh"
         )
 
@@ -180,7 +180,7 @@ final class LaunchLoggerTests: XCTestCase {
             environmentVariables: ["FF_PROJECT": "test"],
             workingDirectory: "/tmp/test",
             toolPaths: LaunchLogEntry.ToolPaths(claude: "/usr/local/bin/claude", tmux: nil, ffRun: nil),
-            settings: LaunchLogEntry.Settings(tmuxMode: false, bypassPermissions: false, agentTeams: false, autoRenameBranch: false),
+            settings: LaunchLogEntry.Settings(tmuxMode: false, bypassPermissions: false, agentTeams: false, autoRenameBranch: false, allowOutsideWorktree: false),
             shell: "/bin/zsh"
         )
     }


### PR DESCRIPTION
## Summary
- Adds "Allow writes outside worktree" toggle in Coding Agent settings (default: off)
- When disabled, injects a system prompt constraining the agent to only write within the worktree directory
- Fixes latent bug where multiple `--append-system-prompt` flags didn't stack (last one wins); prompts are now concatenated into a single flag
- Documents system prompt behavior in AGENTS.md

## Test plan
- [x] Build succeeds
- [x] Tests pass
- [x] Verified multiple `--append-system-prompt` flags don't stack via CLI test

🤖 Generated with [Claude Code](https://claude.com/claude-code)