### PR TITLE
fix(worktrees): avoid prune prompt for newly created workstreams

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -87,11 +87,11 @@
 "Uncommitted changes" = "Canvis sense confirmar";
 "Commits ahead" = "Commits per endavant";
 "Open as workstream" = "Obre com a flux de treball";
-"Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Arbres de treball al disc per a aquest repositori. La neteja elimina els arbres de treball nets i els seus fluxos de treball associats.";
+"Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream." = "Arbres de treball al disc per a aquest repositori. La neteja elimina els arbres de treball nets que no estan associats a cap flux de treball.";
 "Prune %d clean worktree" = "Neteja %d arbre de treball net";
 "Prune %d clean worktrees" = "Neteja %d arbres de treball nets";
-"Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "Vols eliminar %d arbre de treball sense canvis sense confirmar? Els fluxos de treball associats també s'eliminaran de la barra lateral.";
-"Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "Vols eliminar %d arbres de treball sense canvis sense confirmar? Els fluxos de treball associats també s'eliminaran de la barra lateral.";
+"Remove %d clean worktree with no uncommitted changes?" = "Vols eliminar %d arbre de treball net sense canvis sense confirmar?";
+"Remove %d clean worktrees with no uncommitted changes?" = "Vols eliminar %d arbres de treball nets sense canvis sense confirmar?";
 "Remove \"%@\" from the list? Files in %@ will not be deleted." = "Vols eliminar \"%@\" de la llista? Els fitxers a %@ no s'esborraran.";
 
 /* Projects */

--- a/Localization/de.lproj/Localizable.strings
+++ b/Localization/de.lproj/Localizable.strings
@@ -87,11 +87,11 @@
 "Uncommitted changes" = "Nicht committete Änderungen";
 "Commits ahead" = "Commits voraus";
 "Open as workstream" = "Als Workstream öffnen";
-"Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Worktrees auf der Festplatte für dieses Repository. Bereinigen entfernt saubere Worktrees und ihre zugehörigen Workstreams.";
+"Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream." = "Worktrees auf der Festplatte für dieses Repository. Beim Bereinigen werden saubere Worktrees entfernt, die keinem Workstream zugeordnet sind.";
 "Prune %d clean worktree" = "%d sauberen Worktree bereinigen";
 "Prune %d clean worktrees" = "%d saubere Worktrees bereinigen";
-"Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "%d Worktree ohne nicht committete Änderungen entfernen? Zugehörige Workstreams werden ebenfalls aus der Seitenleiste entfernt.";
-"Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "%d Worktrees ohne nicht committete Änderungen entfernen? Zugehörige Workstreams werden ebenfalls aus der Seitenleiste entfernt.";
+"Remove %d clean worktree with no uncommitted changes?" = "%d sauberen Worktree ohne nicht committete Änderungen entfernen?";
+"Remove %d clean worktrees with no uncommitted changes?" = "%d saubere Worktrees ohne nicht committete Änderungen entfernen?";
 "Remove \"%@\" from the list? Files in %@ will not be deleted." = "\"%@\" aus der Liste entfernen? Dateien in %@ werden nicht gelöscht.";
 
 /* Projects */

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -87,11 +87,11 @@
 "Uncommitted changes" = "Uncommitted changes";
 "Commits ahead" = "Commits ahead";
 "Open as workstream" = "Open as workstream";
-"Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams.";
+"Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream." = "Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream.";
 "Prune %d clean worktree" = "Prune %d clean worktree";
 "Prune %d clean worktrees" = "Prune %d clean worktrees";
-"Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar.";
-"Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar.";
+"Remove %d clean worktree with no uncommitted changes?" = "Remove %d clean worktree with no uncommitted changes?";
+"Remove %d clean worktrees with no uncommitted changes?" = "Remove %d clean worktrees with no uncommitted changes?";
 "Remove \"%@\" from the list? Files in %@ will not be deleted." = "Remove \"%@\" from the list? Files in %@ will not be deleted.";
 
 /* Projects */

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -87,11 +87,11 @@
 "Uncommitted changes" = "Cambios sin confirmar";
 "Commits ahead" = "Commits por delante";
 "Open as workstream" = "Abrir como flujo de trabajo";
-"Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Árboles de trabajo en disco para este repositorio. La limpieza elimina los árboles de trabajo limpios y sus flujos de trabajo asociados.";
+"Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream." = "Árboles de trabajo en disco para este repositorio. La limpieza elimina los árboles de trabajo limpios que no están asociados a un flujo de trabajo.";
 "Prune %d clean worktree" = "Limpiar %d árbol de trabajo limpio";
 "Prune %d clean worktrees" = "Limpiar %d árboles de trabajo limpios";
-"Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "¿Eliminar %d árbol de trabajo sin cambios sin confirmar? Los flujos de trabajo asociados también se eliminarán de la barra lateral.";
-"Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "¿Eliminar %d árboles de trabajo sin cambios sin confirmar? Los flujos de trabajo asociados también se eliminarán de la barra lateral.";
+"Remove %d clean worktree with no uncommitted changes?" = "¿Eliminar %d árbol de trabajo limpio sin cambios sin confirmar?";
+"Remove %d clean worktrees with no uncommitted changes?" = "¿Eliminar %d árboles de trabajo limpios sin cambios sin confirmar?";
 "Remove \"%@\" from the list? Files in %@ will not be deleted." = "¿Eliminar \"%@\" de la lista? Los archivos en %@ no se borrarán.";
 
 /* Projects */

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -87,11 +87,11 @@
 "Uncommitted changes" = "Osparade ändringar";
 "Commits ahead" = "Commits före";
 "Open as workstream" = "Öppna som arbetsflöde";
-"Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams." = "Arbetsträd på disk för detta repository. Rensning tar bort rena arbetsträd och deras associerade arbetsflöden.";
+"Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream." = "Arbetsträd på disk för detta repository. Rensning tar bort rena arbetsträd som inte är associerade med ett arbetsflöde.";
 "Prune %d clean worktree" = "Rensa %d rent arbetsträd";
 "Prune %d clean worktrees" = "Rensa %d rena arbetsträd";
-"Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "Ta bort %d arbetsträd utan osparade ändringar? Associerade arbetsflöden kommer också att tas bort från sidofältet.";
-"Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar." = "Ta bort %d arbetsträd utan osparade ändringar? Associerade arbetsflöden kommer också att tas bort från sidofältet.";
+"Remove %d clean worktree with no uncommitted changes?" = "Ta bort %d rent arbetsträd utan osparade ändringar?";
+"Remove %d clean worktrees with no uncommitted changes?" = "Ta bort %d rena arbetsträd utan osparade ändringar?";
 "Remove \"%@\" from the list? Files in %@ will not be deleted." = "Ta bort \"%@\" från listan? Filer i %@ kommer inte att raderas.";
 
 /* Projects */

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -284,12 +284,18 @@ enum GitOperations {
         return results
     }
 
-    /// Remove all worktrees that have no uncommitted changes and no unmerged branch commits.
+    /// Remove clean worktrees (no uncommitted changes and no unmerged branch commits).
+    /// When `onlyPaths` is provided, only those worktree paths are considered.
     @discardableResult
-    static func pruneCleanWorktrees(at projectPath: String) -> Int {
+    static func pruneCleanWorktrees(at projectPath: String, onlyPaths: Set<String>? = nil) -> Int {
         let worktrees = listWorktreesWithInfo(at: projectPath)
+        let allowedPaths = onlyPaths.map { Set($0.map { URL(fileURLWithPath: $0).standardizedFileURL.path }) }
         var pruned = 0
         for wt in worktrees where !wt.isMain && !wt.isDirty && !wt.hasBranchCommits {
+            let standardizedPath = URL(fileURLWithPath: wt.path).standardizedFileURL.path
+            if let allowedPaths, !allowedPaths.contains(standardizedPath) {
+                continue
+            }
             let result = run(args: ["worktree", "remove", wt.path], in: projectPath)
             if result != nil {
                 pruned += 1

--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -289,7 +289,11 @@ enum GitOperations {
     @discardableResult
     static func pruneCleanWorktrees(at projectPath: String, onlyPaths: Set<String>? = nil) -> Int {
         let worktrees = listWorktreesWithInfo(at: projectPath)
-        let allowedPaths = onlyPaths.map { Set($0.map { URL(fileURLWithPath: $0).standardizedFileURL.path }) }
+        let allowedPaths = onlyPaths.map { paths in
+            Set(paths.map { path in
+                URL(fileURLWithPath: path).standardizedFileURL.path
+            })
+        }
         var pruned = 0
         for wt in worktrees where !wt.isMain && !wt.isDirty && !wt.hasBranchCommits {
             let standardizedPath = URL(fileURLWithPath: wt.path).standardizedFileURL.path

--- a/Sources/Views/ProjectOverviewView.swift
+++ b/Sources/Views/ProjectOverviewView.swift
@@ -192,7 +192,7 @@ struct ProjectOverviewView: View {
                             WorktreeInfoRow(
                                 worktree: wt,
                                 projectDirectory: project.directory,
-                                isWorkstream: workstreamPaths.contains(wt.path),
+                                isWorkstream: workstreamPaths.contains(Self.standardizedPath(wt.path)),
                                 onAdopt: { adoptWorktree(wt) }
                             )
                         }
@@ -218,7 +218,7 @@ struct ProjectOverviewView: View {
                                 .foregroundStyle(.secondary)
                         }
                     } footer: {
-                        Text("Worktrees on disk for this repository. Pruning removes clean worktrees and their associated workstreams.")
+                        Text("Worktrees on disk for this repository. Pruning removes clean worktrees that are not associated with a workstream.")
                     }
                 }
             }
@@ -261,16 +261,27 @@ struct ProjectOverviewView: View {
             Button("Cancel", role: .cancel) {}
             Button("Prune", role: .destructive) { pruneWorktrees() }
         } message: {
-            Text(String(format: NSLocalizedString(prunableCount == 1 ? "Remove %d worktree with no uncommitted changes? Associated workstreams will also be removed from the sidebar." : "Remove %d worktrees with no uncommitted changes? Associated workstreams will also be removed from the sidebar.", comment: ""), prunableCount))
+            Text(String(format: NSLocalizedString(prunableCount == 1 ? "Remove %d clean worktree with no uncommitted changes?" : "Remove %d clean worktrees with no uncommitted changes?", comment: ""), prunableCount))
         }
     }
 
     private var workstreamPaths: Set<String> {
-        Set(project.workstreams.compactMap(\.worktreePath))
+        Set(project.workstreams.compactMap(\.worktreePath).map(Self.standardizedPath))
+    }
+
+    private var prunableWorktrees: [WorktreeInfo] {
+        return worktrees.filter { worktree in
+            guard !worktree.isMain && !worktree.isDirty && !worktree.hasBranchCommits else { return false }
+            return !workstreamPaths.contains(Self.standardizedPath(worktree.path))
+        }
+    }
+
+    private var prunablePaths: Set<String> {
+        Set(prunableWorktrees.map(\.path).map(Self.standardizedPath))
     }
 
     private var prunableCount: Int {
-        worktrees.filter { !$0.isMain && !$0.isDirty && !$0.hasBranchCommits }.count
+        prunableWorktrees.count
     }
 
     private func adoptWorktree(_ worktree: WorktreeInfo) {
@@ -307,10 +318,10 @@ struct ProjectOverviewView: View {
     private func pruneWorktrees() {
         isPruning = true
         let dir = project.directory
-        let prunablePaths = Set(worktrees.filter { !$0.isMain && !$0.isDirty && !$0.hasBranchCommits }.map(\.path))
+        let pathsToPrune = prunablePaths
         Task.detached {
-            GitOperations.pruneCleanWorktrees(at: dir)
-            await applyPrunedWorktrees(prunablePaths)
+            GitOperations.pruneCleanWorktrees(at: dir, onlyPaths: pathsToPrune)
+            await applyPrunedWorktrees(pathsToPrune)
         }
     }
 
@@ -337,11 +348,15 @@ struct ProjectOverviewView: View {
     private func applyPrunedWorktrees(_ prunablePaths: Set<String>) {
         project.workstreams.removeAll { ws in
             guard let path = ws.worktreePath else { return false }
-            return prunablePaths.contains(path)
+            return prunablePaths.contains(Self.standardizedPath(path))
         }
         onProjectChanged()
         isPruning = false
         refreshWorktrees()
+    }
+
+    private static func standardizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
     }
 }
 

--- a/Tests/GitOperationsTests.swift
+++ b/Tests/GitOperationsTests.swift
@@ -269,6 +269,30 @@ final class GitOperationsTests: XCTestCase {
                       "Working tree should still be dirty")
     }
 
+    // MARK: - pruneCleanWorktrees
+
+    func testPruneCleanWorktreesPrunesOnlyRequestedPaths() throws {
+        let repoDir = tempDir.appendingPathComponent("prune-filtered")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        git(["init", "-b", "main"], in: repoDir)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
+             "commit", "--allow-empty", "-m", "init"], in: repoDir)
+
+        let worktreeA = tempDir.appendingPathComponent("worktree-a")
+        let worktreeB = tempDir.appendingPathComponent("worktree-b")
+        XCTAssertTrue(git(["worktree", "add", "-b", "feature/a", worktreeA.path], in: repoDir))
+        XCTAssertTrue(git(["worktree", "add", "-b", "feature/b", worktreeB.path], in: repoDir))
+
+        let pruned = GitOperations.pruneCleanWorktrees(
+            at: repoDir.path,
+            onlyPaths: Set([worktreeA.path])
+        )
+
+        XCTAssertEqual(pruned, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: worktreeA.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktreeB.path))
+    }
+
     // MARK: - Helpers
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Prevents brand-new workstream worktrees from being shown as immediately prunable
- Restricts prune candidates to **clean orphan worktrees** (not associated with any workstream)
- Updates prune copy to match orphan-only behavior
- Adds test coverage for path-scoped prune behavior

## Changes
- `ProjectOverviewView`: compute prunable set as clean + no unique branch commits + not main + not associated with a workstream
- `GitOperations.pruneCleanWorktrees(...)`: add optional `onlyPaths` filter so pruning can be explicitly scoped
- `GitOperationsTests`: add `testPruneCleanWorktreesPrunesOnlyRequestedPaths`
- Localization updates (`en/es/ca/sv`) for prune messaging

## Test plan
- [x] Create a new workstream and verify no prune warning appears immediately
- [x] Confirm prune UI text states orphan-only behavior
- [x] Run `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/dev.sh test`
