### PR TITLE
fix: show correct shortcut numbers on closeable tabs

### DIFF
--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -816,7 +816,7 @@ struct TerminalContainerView: View {
 
     private func closeableTabShortcut(_ tab: WorkspaceTab) -> String? {
         guard tab.isCloseable,
-              let idx = tabs.filter(\.isCloseable).firstIndex(of: tab),
+              let idx = tabs.firstIndex(of: tab),
               idx < 9 else { return nil }
         return "\(idx + 1)"
     }


### PR DESCRIPTION
## Summary
- Tab shortcut labels (⌘1, ⌘2, etc.) on terminal/browser tabs were numbered relative to closeable tabs only, ignoring fixed tabs (Info, Agent, Environment)
- Since Cmd+1-9 maps to all tabs in display order, the labels were misleading (e.g., first terminal showed ⌘1 but Cmd+1 activated the Info tab)
- Fixed by using the tab's index in the full tab array instead of the filtered closeable-only array

Closes #387

## Test plan
- [ ] Open a workstream with default tabs (Info, Agent, Environment)
- [ ] Add a terminal tab (Cmd+T) and verify its shortcut label shows ⌘4 (not ⌘1)
- [ ] Add a browser tab (Cmd+B) and verify its shortcut label shows ⌘5
- [ ] Verify pressing Cmd+4 switches to the terminal tab
- [ ] Verify Cmd+1/2/3 still switch to Info/Agent/Environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)