### PR TITLE
fix: auto-focus terminal when selecting workstream from sidebar

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -307,6 +307,12 @@ struct ContentView: View {
                 if newValue != .settings && newValue != .help {
                     newValue?.save()
                 }
+                // Auto-focus terminal when selecting a workstream
+                if case .workstream = newValue {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .focusAgent, object: nil)
+                    }
+                }
             }
             .onKeyPress(.escape) {
                 if selection == .settings || selection == .help {


### PR DESCRIPTION
## Summary
- Post `.focusAgent` notification when sidebar selection changes to a workstream, so keyboard input goes to the terminal instead of staying in the SwiftUI `List`
- Uses `DispatchQueue.main.async` to ensure the workstream view is mounted before focus transfers

Closes #394

## Test plan
- [ ] Click a workstream in the sidebar, immediately start typing -- keystrokes should go to the terminal
- [ ] Verify Cmd+Return still focuses the agent tab as before
- [ ] Verify selecting projects, settings, and help does not trigger terminal focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)