### PR TITLE
fix: rename Abandon PR to Close PR to match GitHub terminology

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -276,7 +276,7 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Crear PR";
-"Abandon PR" = "Abandonar PR";
+"Close PR" = "Tancar PR";
 "This branch has been merged." = "Aquesta branca s'ha fusionat.";
 "gh CLI is not installed." = "gh CLI no està instal·lat.";
 "Claude Code is not installed." = "Claude Code no està instal·lat.";

--- a/Localization/de.lproj/Localizable.strings
+++ b/Localization/de.lproj/Localizable.strings
@@ -273,7 +273,7 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "PR erstellen";
-"Abandon PR" = "PR aufgeben";
+"Close PR" = "PR schließen";
 "This branch has been merged." = "Dieser Branch wurde gemergt.";
 "gh CLI is not installed." = "gh CLI ist nicht installiert.";
 "Claude Code is not installed." = "Claude Code ist nicht installiert.";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -276,7 +276,7 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Create PR";
-"Abandon PR" = "Abandon PR";
+"Close PR" = "Close PR";
 "This branch has been merged." = "This branch has been merged.";
 "gh CLI is not installed." = "gh CLI is not installed.";
 "Claude Code is not installed." = "Claude Code is not installed.";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -276,7 +276,7 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Crear PR";
-"Abandon PR" = "Abandonar PR";
+"Close PR" = "Cerrar PR";
 "This branch has been merged." = "Esta rama ha sido fusionada.";
 "gh CLI is not installed." = "gh CLI no está instalado.";
 "Claude Code is not installed." = "Claude Code no está instalado.";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -276,7 +276,7 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Skapa PR";
-"Abandon PR" = "Överge PR";
+"Close PR" = "Stäng PR";
 "This branch has been merged." = "Denna gren har mergats.";
 "gh CLI is not installed." = "gh CLI är inte installerat.";
 "Claude Code is not installed." = "Claude Code är inte installerat.";

--- a/Sources/Models/QuickActionRunner.swift
+++ b/Sources/Models/QuickActionRunner.swift
@@ -10,7 +10,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
     case commit
     case push
     case createPR
-    case abandonPR
+    case closePR
 
     var id: String {
         rawValue
@@ -21,7 +21,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
         case .commit: return NSLocalizedString("Commit", comment: "")
         case .push: return NSLocalizedString("Push", comment: "")
         case .createPR: return NSLocalizedString("Create PR", comment: "")
-        case .abandonPR: return NSLocalizedString("Abandon PR", comment: "")
+        case .closePR: return NSLocalizedString("Close PR", comment: "")
         }
     }
 
@@ -30,7 +30,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
         case .commit: return "checkmark.circle"
         case .push: return "arrow.up"
         case .createPR: return "arrow.triangle.pull"
-        case .abandonPR: return "xmark.circle"
+        case .closePR: return "xmark.circle"
         }
     }
 
@@ -38,13 +38,13 @@ enum QuickAction: String, CaseIterable, Identifiable {
     var usesLLM: Bool {
         switch self {
         case .commit, .createPR: return true
-        case .push, .abandonPR: return false
+        case .push, .closePR: return false
         }
     }
 
     var requiresGitHubRemote: Bool {
         switch self {
-        case .createPR, .abandonPR: return true
+        case .createPR, .closePR: return true
         case .commit, .push: return false
         }
     }
@@ -55,7 +55,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
             return "Stage and commit all changes in the working tree with a good commit message based on the changes. Do not push."
         case .createPR:
             return "Create a pull request for the current changes. Write a clear title and description based on what we've been working on."
-        case .push, .abandonPR:
+        case .push, .closePR:
             return nil
         }
     }
@@ -103,9 +103,9 @@ final class QuickActionRunner: ObservableObject {
             runClaudeAction(action: action, claudePath: claudePath, workingDirectory: workingDirectory)
         case .push:
             runPush(workingDirectory: workingDirectory)
-        case .abandonPR:
+        case .closePR:
             guard let ghPath, let branchName else { return }
-            runAbandonPR(ghPath: ghPath, branchName: branchName, workingDirectory: workingDirectory)
+            runClosePR(ghPath: ghPath, branchName: branchName, workingDirectory: workingDirectory)
         }
     }
 
@@ -150,11 +150,11 @@ final class QuickActionRunner: ObservableObject {
         }
     }
 
-    private func runAbandonPR(ghPath: String, branchName: String, workingDirectory: String) {
-        let command = "\(ghPath) pr close \(branchName) --comment 'Abandoned from Factory Floor'"
+    private func runClosePR(ghPath: String, branchName: String, workingDirectory: String) {
+        let command = "\(ghPath) pr close \(branchName) --comment 'Closed from Factory Floor'"
 
-        appendLog(action: .abandonPR, command: command)
-        logger.info("Quick action abandonPR starting in \(workingDirectory)")
+        appendLog(action: .closePR, command: command)
+        logger.info("Quick action closePR starting in \(workingDirectory)")
 
         let dir = workingDirectory
         let path = ghPath
@@ -163,7 +163,7 @@ final class QuickActionRunner: ObservableObject {
             let process = Process()
             let pipe = Pipe()
             process.executableURL = URL(fileURLWithPath: path)
-            process.arguments = ["pr", "close", branch, "--comment", "Abandoned from Factory Floor"]
+            process.arguments = ["pr", "close", branch, "--comment", "Closed from Factory Floor"]
             process.currentDirectoryURL = URL(fileURLWithPath: dir)
             process.standardOutput = pipe
             process.standardError = pipe
@@ -182,9 +182,9 @@ final class QuickActionRunner: ObservableObject {
             await MainActor.run {
                 self.updateLog(output: output, exitCode: success ? 0 : 1)
                 self.runningProcess = nil
-                self.state = success ? .succeeded(.abandonPR) : .failed(.abandonPR)
+                self.state = success ? .succeeded(.closePR) : .failed(.closePR)
                 if success {
-                    self.onSuccess?(.abandonPR)
+                    self.onSuccess?(.closePR)
                 }
                 self.scheduleDismiss()
             }

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -909,10 +909,10 @@ struct TerminalContainerView: View {
         quickActionRunner.onSuccess = { action in
             appEnv.refreshWorktreeState(for: workingDirectory, projectDirectory: projectDirectory)
             if let branch = appEnv.branchName(for: workingDirectory) {
-                if action == .abandonPR {
+                if action == .closePR {
                     appEnv.clearBranchPR(for: projectDirectory, branch: branch)
                 }
-                if action == .createPR || action == .abandonPR {
+                if action == .createPR || action == .closePR {
                     appEnv.refreshGitHubInfo(for: projectDirectory, branch: branch)
                 }
             }
@@ -1164,7 +1164,7 @@ private struct QuickActionButtons: View {
             return worktreeState.hasUnpushedCommits && worktreeState.hasRemote
         case .createPR:
             return hasGitHubRemote && worktreeState.hasBranchCommits && prState == nil
-        case .abandonPR:
+        case .closePR:
             return hasOpenPR
         }
     }
@@ -1178,7 +1178,7 @@ private struct QuickActionButtons: View {
                 return NSLocalizedString("Enable \"Bypass permission prompts\" in Settings.", comment: "")
             }
         }
-        if action == .abandonPR, ghPath == nil {
+        if action == .closePR, ghPath == nil {
             return NSLocalizedString("gh CLI is not installed.", comment: "")
         }
         return nil

--- a/website/content/ca/docs.md
+++ b/website/content/ca/docs.md
@@ -100,7 +100,7 @@ Les quick actions executen tasques puntuals de Claude des del sidebar:
 - **Commit** — prepara i fa commit amb un missatge generat per IA
 - **Push** — fa push de la branch actual a l'origin
 - **Create PR** — crea una pull request amb títol i descripció generats per IA
-- **Abandon PR** — tanca la PR
+- **Close PR** — tanca la PR
 
 S'executen com a crides `claude -p` en segon pla. Activa **Quick action debug mode** a la configuració si vols saber com es fa l'embotit. Confia en nosaltres, en [David](https://davidpoblador.com) va passar més temps del que pot admetre depurant comportaments estranys allà dins.
 
@@ -296,7 +296,7 @@ Requereix el [gh CLI](https://cli.github.com/) amb autenticació (`gh auth login
 
 #### Quick actions {#quick-actions-1}
 
-Des del sidebar, executa operacions d'un sol clic: **Create PR** (títol i descripció generats per IA), **Push** (a l'origin amb `-u`), o **Abandon PR** (tanca amb un comentari). Perquè si estàs cansat d'escriure "ara fes commit, push, i obre una PR" a Claude per centèsima vegada, no ets l'únic.
+Des del sidebar, executa operacions d'un sol clic: **Create PR** (títol i descripció generats per IA), **Push** (a l'origin amb `-u`), o **Close PR** (tanca amb un comentari). Perquè si estàs cansat d'escriure "ara fes commit, push, i obre una PR" a Claude per centèsima vegada, no ets l'únic.
 
 ### Actualitzacions {#updates}
 

--- a/website/content/de/docs.md
+++ b/website/content/de/docs.md
@@ -100,7 +100,7 @@ Schnellaktionen führen einmalige Claude-Aufgaben aus der Seitenleiste aus:
 - **Commit** — staged und committet mit einer KI-generierten Nachricht
 - **Push** — pusht den aktuellen Branch zu Origin
 - **Create PR** — erstellt einen Pull Request mit KI-generiertem Titel und Beschreibung
-- **Abandon PR** — schließt den PR
+- **Close PR** — schließt den PR
 
 Diese laufen als Hintergrund-`claude -p`-Aufrufe. Aktiviere **Quick action debug mode** in den Einstellungen, wenn du wissen willst, wie die Wurst gemacht wird. Vertrau uns, [David](https://davidpoblador.com) hat mehr Zeit als er zugeben will damit verbracht, seltsame Verhaltensweisen dort drin zu debuggen.
 
@@ -296,7 +296,7 @@ Erfordert die [gh CLI](https://cli.github.com/) mit Authentifizierung (`gh auth 
 
 #### Schnellaktionen {#quick-actions-1}
 
-Aus der Seitenleiste Ein-Klick-Operationen ausführen: **Create PR** (KI-generierter Titel und Beschreibung), **Push** (zu Origin mit `-u`) oder **Abandon PR** (schließt mit Kommentar). Weil wenn du es satt hast, „now commit, push, and open a PR" zum hundertsten Mal in Claude zu tippen, bist du nicht allein.
+Aus der Seitenleiste Ein-Klick-Operationen ausführen: **Create PR** (KI-generierter Titel und Beschreibung), **Push** (zu Origin mit `-u`) oder **Close PR** (schließt mit Kommentar). Weil wenn du es satt hast, „now commit, push, and open a PR" zum hundertsten Mal in Claude zu tippen, bist du nicht allein.
 
 ### Updates {#updates}
 

--- a/website/content/docs.md
+++ b/website/content/docs.md
@@ -100,7 +100,7 @@ Quick actions run one-shot Claude tasks from the sidebar:
 - **Commit** — stages and commits with an AI-generated message
 - **Push** — pushes the current branch to origin
 - **Create PR** — creates a pull request with AI-generated title and description
-- **Abandon PR** — closes the PR
+- **Close PR** — closes the PR
 
 These run as background `claude -p` calls. Enable **Quick action debug mode** in settings if you want to know how the sausage is made. Trust us, [David](https://davidpoblador.com) spent more time than he can admit debugging weird behaviors in there.
 
@@ -296,7 +296,7 @@ Requires the [gh CLI](https://cli.github.com/) with authentication (`gh auth log
 
 #### Quick actions
 
-From the sidebar, run one-click operations: **Create PR** (AI-generated title and description), **Push** (to origin with `-u`), or **Abandon PR** (closes with a comment). Because if you're tired of typing "now commit, push, and open a PR" into Claude for the hundredth time, you're not alone.
+From the sidebar, run one-click operations: **Create PR** (AI-generated title and description), **Push** (to origin with `-u`), or **Close PR** (closes with a comment). Because if you're tired of typing "now commit, push, and open a PR" into Claude for the hundredth time, you're not alone.
 
 ### Updates
 

--- a/website/content/es/docs.md
+++ b/website/content/es/docs.md
@@ -100,7 +100,7 @@ Las quick actions ejecutan tareas puntuales de Claude desde el sidebar:
 - **Commit** — hace stage y commit con un mensaje generado por IA
 - **Push** — hace push de la branch actual al origin
 - **Create PR** — crea un pull request con título y descripción generados por IA
-- **Abandon PR** — cierra el PR
+- **Close PR** — cierra el PR
 
 Se ejecutan como llamadas `claude -p` en segundo plano. Activa **Quick action debug mode** en ajustes si quieres saber cómo se hace la salchicha. Confía en nosotros, [David](https://davidpoblador.com) pasó más tiempo del que puede admitir depurando comportamientos extraños ahí dentro.
 
@@ -296,7 +296,7 @@ Requiere el [gh CLI](https://cli.github.com/) con autenticación (`gh auth login
 
 #### Quick actions {#quick-actions-1}
 
-Desde el sidebar, ejecuta operaciones con un clic: **Create PR** (título y descripción generados por IA), **Push** (al origin con `-u`), o **Abandon PR** (cierra con un comentario). Porque si estás cansado de escribir "ahora haz commit, push y abre un PR" en Claude por centésima vez, no estás solo.
+Desde el sidebar, ejecuta operaciones con un clic: **Create PR** (título y descripción generados por IA), **Push** (al origin con `-u`), o **Close PR** (cierra con un comentario). Porque si estás cansado de escribir "ahora haz commit, push y abre un PR" en Claude por centésima vez, no estás solo.
 
 ### Actualizaciones {#updates}
 

--- a/website/content/sv/docs.md
+++ b/website/content/sv/docs.md
@@ -100,7 +100,7 @@ Quick actions kör engångs-Claude-uppgifter från sidebar:
 - **Commit** — stagear och committar med ett AI-genererat meddelande
 - **Push** — pushar nuvarande branch till origin
 - **Create PR** — skapar en pull request med AI-genererad titel och beskrivning
-- **Abandon PR** — stänger PRn
+- **Close PR** — stänger PRn
 
 Dessa körs som bakgrunds-`claude -p`-anrop. Aktivera **Quick action debug mode** i inställningarna om du vill veta hur korven görs. Lita på oss, [David](https://davidpoblador.com) lade ner mer tid än han vill erkänna på att debugga konstiga beteenden där inne.
 
@@ -296,7 +296,7 @@ Kräver [gh CLI](https://cli.github.com/) med autentisering (`gh auth login`).
 
 #### Quick actions {#quick-actions-1}
 
-Från sidebar, kör ett-klicks-operationer: **Create PR** (AI-genererad titel och beskrivning), **Push** (till origin med `-u`), eller **Abandon PR** (stänger med en kommentar). För om du är trött på att skriva "now commit, push, and open a PR" till Claude för hundrade gången, är du inte ensam.
+Från sidebar, kör ett-klicks-operationer: **Create PR** (AI-genererad titel och beskrivning), **Push** (till origin med `-u`), eller **Close PR** (stänger med en kommentar). För om du är trött på att skriva "now commit, push, and open a PR" till Claude för hundrade gången, är du inte ensam.
 
 ### Uppdateringar {#updates}
 


### PR DESCRIPTION
## Summary
- Renamed `abandonPR` enum case to `closePR` and updated all references in `QuickActionRunner` and `TerminalContainerView`
- Changed the `--comment` flag text from "Abandoned from Factory Floor" to "Closed from Factory Floor"
- Updated localization strings in all 5 locales (en, ca, de, es, sv)
- Updated website docs in all 5 languages

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)