### PR TITLE
fix: stop advancing local main HEAD during worktree creation

### DIFF
--- a/Sources/Models/GitOperations.swift
+++ b/Sources/Models/GitOperations.swift
@@ -109,8 +109,8 @@ enum GitOperations {
             ? workstreamName
             : "\(branchPrefix)/\(workstreamName)"
 
-        // Fetch and fast-forward the default branch so worktrees start from latest
-        updateDefaultBranch(at: projectPath)
+        // Fetch the default branch so worktrees start from the latest remote ref
+        fetchDefaultBranch(at: projectPath)
 
         let baseBranch = defaultBranch(at: projectPath)
 
@@ -349,43 +349,6 @@ enum GitOperations {
     /// Delete a local branch by name.
     static func deleteLocalBranch(at path: String, branchName: String) {
         _ = run(args: ["branch", "-D", branchName], in: path)
-    }
-
-    /// Fetch the default branch from origin, fast-forward the local ref to match,
-    /// and reset the working tree if it is clean. Fails silently when there is no
-    /// remote, the network is unreachable, or the working tree has local changes.
-    static func updateDefaultBranch(at path: String) {
-        guard run(args: ["remote", "get-url", "origin"], in: path) != nil else { return }
-
-        let branch: String
-        if let ref = run(args: ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"], in: path) {
-            branch = ref.trimmingCharacters(in: .whitespacesAndNewlines)
-                .replacingOccurrences(of: "origin/", with: "")
-        } else if run(args: ["rev-parse", "--verify", "refs/heads/main"], in: path) != nil {
-            branch = "main"
-        } else if run(args: ["rev-parse", "--verify", "refs/heads/master"], in: path) != nil {
-            branch = "master"
-        } else {
-            return
-        }
-
-        // Fetch with timeout so we don't block the UI
-        guard runWithTimeout(args: ["fetch", "origin", branch, "--no-tags"], in: path, timeout: 5) != nil else {
-            return
-        }
-
-        // Move the local ref to match origin
-        guard run(args: ["update-ref", "refs/heads/\(branch)", "refs/remotes/origin/\(branch)"], in: path) != nil else {
-            return
-        }
-
-        // Reset the working tree only if it is clean
-        if !hasUncommittedChanges(at: path) {
-            _ = run(args: ["reset", "--hard", "--quiet"], in: path)
-            logger.info("[FF] Updated \(branch, privacy: .public) to latest")
-        } else {
-            logger.info("[FF] Updated \(branch, privacy: .public) ref but working tree has local changes, skipping reset")
-        }
     }
 
     // MARK: - Private

--- a/Sources/Models/WorkstreamArchiver.swift
+++ b/Sources/Models/WorkstreamArchiver.swift
@@ -70,7 +70,7 @@ enum WorkstreamArchiver {
                 if let branchName {
                     GitOperations.deleteLocalBranch(at: projectDir, branchName: branchName)
                 }
-                GitOperations.updateDefaultBranch(at: projectDir)
+                GitOperations.fetchDefaultBranch(at: projectDir)
                 if let tmuxPath {
                     TmuxSession.killWorkstreamSessions(tmuxPath: tmuxPath, project: projName, workstream: wsName)
                 }

--- a/Tests/GitOperationsTests.swift
+++ b/Tests/GitOperationsTests.swift
@@ -201,9 +201,9 @@ final class GitOperationsTests: XCTestCase {
         XCTAssertFalse(result, "Branch should have been deleted")
     }
 
-    // MARK: - updateDefaultBranch
+    // MARK: - fetchDefaultBranch
 
-    func testUpdateDefaultBranchSkipsWithoutRemote() throws {
+    func testFetchDefaultBranchSkipsWithoutRemote() throws {
         let repoDir = tempDir.appendingPathComponent("no-remote-update")
         try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
         git(["init", "-b", "main"], in: repoDir)
@@ -211,10 +211,10 @@ final class GitOperationsTests: XCTestCase {
              "commit", "--allow-empty", "-m", "init"], in: repoDir)
 
         // Should return silently without crashing
-        GitOperations.updateDefaultBranch(at: repoDir.path)
+        GitOperations.fetchDefaultBranch(at: repoDir.path)
     }
 
-    func testUpdateDefaultBranchFastForwardsMain() throws {
+    func testFetchDefaultBranchDoesNotMoveLocalRef() throws {
         // Create a "remote" repo
         let remoteDir = tempDir.appendingPathComponent("remote")
         try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
@@ -227,46 +227,20 @@ final class GitOperationsTests: XCTestCase {
         git(["clone", remoteDir.path, repoDir.path], in: tempDir)
 
         // Record the initial commit
-        let beforeSHA = gitOutput(["rev-parse", "HEAD"], in: repoDir)
+        let beforeSHA = gitOutput(["rev-parse", "refs/heads/main"], in: repoDir)
 
         // Add a new commit to remote
         git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
              "commit", "--allow-empty", "-m", "second"], in: remoteDir)
 
-        // Update should fast-forward
-        GitOperations.updateDefaultBranch(at: repoDir.path)
+        // Fetch should update remote tracking ref but not local main
+        GitOperations.fetchDefaultBranch(at: repoDir.path)
 
-        let afterSHA = gitOutput(["rev-parse", "HEAD"], in: repoDir)
-        XCTAssertNotEqual(beforeSHA, afterSHA, "main should have advanced")
-    }
+        let afterSHA = gitOutput(["rev-parse", "refs/heads/main"], in: repoDir)
+        XCTAssertEqual(beforeSHA, afterSHA, "Local main should not have moved")
 
-    func testUpdateDefaultBranchSkipsResetWhenDirty() throws {
-        // Create a "remote" repo
-        let remoteDir = tempDir.appendingPathComponent("remote")
-        try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
-        git(["init", "-b", "main"], in: remoteDir)
-        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
-             "commit", "--allow-empty", "-m", "init"], in: remoteDir)
-
-        // Clone it
-        let repoDir = tempDir.appendingPathComponent("local")
-        git(["clone", remoteDir.path, repoDir.path], in: tempDir)
-
-        // Make a local uncommitted change
-        let dirtyFile = repoDir.appendingPathComponent("dirty.txt")
-        try "local work".write(to: dirtyFile, atomically: true, encoding: .utf8)
-
-        // Add a new commit to remote
-        git(["-c", "user.email=test@test.com", "-c", "user.name=Test",
-             "commit", "--allow-empty", "-m", "second"], in: remoteDir)
-
-        GitOperations.updateDefaultBranch(at: repoDir.path)
-
-        // The dirty file should still be there
-        XCTAssertTrue(FileManager.default.fileExists(atPath: dirtyFile.path),
-                      "Local changes should be preserved")
-        XCTAssertTrue(GitOperations.hasUncommittedChanges(at: repoDir.path),
-                      "Working tree should still be dirty")
+        let remoteSHA = gitOutput(["rev-parse", "refs/remotes/origin/main"], in: repoDir)
+        XCTAssertNotEqual(beforeSHA, remoteSHA, "Remote tracking ref should have advanced")
     }
 
     // MARK: - pruneCleanWorktrees


### PR DESCRIPTION
## Summary
- Remove `updateDefaultBranch()` which used `git update-ref` to fast-forward the local default branch, causing phantom staged changes in the main worktree
- Replace with `fetchDefaultBranch()` (fetch-only) in both worktree creation and archiving paths
- `defaultBranch()` already prefers remote tracking refs (`origin/main`), so `git worktree add -b <name> <path> origin/main` works without needing a local main ref

Closes #393

## Test plan
- [x] Updated tests to verify `fetchDefaultBranch` does NOT move local `refs/heads/main`
- [x] All 180 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)