### PR TITLE
feat: consolidate GitHub actions into contextual dropdown

### DIFF
--- a/Localization/ca.lproj/Localizable.strings
+++ b/Localization/ca.lproj/Localizable.strings
@@ -276,7 +276,8 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Crear PR";
-"Abandon PR" = "Abandonar PR";
+"Close PR" = "Tancar PR";
+"Open #%d" = "Obrir #%d";
 "This branch has been merged." = "Aquesta branca s'ha fusionat.";
 "gh CLI is not installed." = "gh CLI no està instal·lat.";
 "Claude Code is not installed." = "Claude Code no està instal·lat.";

--- a/Localization/de.lproj/Localizable.strings
+++ b/Localization/de.lproj/Localizable.strings
@@ -273,7 +273,8 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "PR erstellen";
-"Abandon PR" = "PR aufgeben";
+"Close PR" = "PR schließen";
+"Open #%d" = "#%d öffnen";
 "This branch has been merged." = "Dieser Branch wurde gemergt.";
 "gh CLI is not installed." = "gh CLI ist nicht installiert.";
 "Claude Code is not installed." = "Claude Code ist nicht installiert.";

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -276,7 +276,8 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Create PR";
-"Abandon PR" = "Abandon PR";
+"Close PR" = "Close PR";
+"Open #%d" = "Open #%d";
 "This branch has been merged." = "This branch has been merged.";
 "gh CLI is not installed." = "gh CLI is not installed.";
 "Claude Code is not installed." = "Claude Code is not installed.";

--- a/Localization/es.lproj/Localizable.strings
+++ b/Localization/es.lproj/Localizable.strings
@@ -276,7 +276,8 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Crear PR";
-"Abandon PR" = "Abandonar PR";
+"Close PR" = "Cerrar PR";
+"Open #%d" = "Abrir #%d";
 "This branch has been merged." = "Esta rama ha sido fusionada.";
 "gh CLI is not installed." = "gh CLI no está instalado.";
 "Claude Code is not installed." = "Claude Code no está instalado.";

--- a/Localization/sv.lproj/Localizable.strings
+++ b/Localization/sv.lproj/Localizable.strings
@@ -276,7 +276,8 @@
 "Commit" = "Commit";
 "Push" = "Push";
 "Create PR" = "Skapa PR";
-"Abandon PR" = "Överge PR";
+"Close PR" = "Stäng PR";
+"Open #%d" = "Öppna #%d";
 "This branch has been merged." = "Denna gren har mergats.";
 "gh CLI is not installed." = "gh CLI är inte installerat.";
 "Claude Code is not installed." = "Claude Code är inte installerat.";

--- a/Sources/Models/GitHubOperations.swift
+++ b/Sources/Models/GitHubOperations.swift
@@ -12,7 +12,7 @@ struct GitHubRepoInfo {
     let openIssues: Int
 }
 
-struct GitHubPR {
+struct GitHubPR: Equatable {
     let number: Int
     let title: String
     let state: String

--- a/Sources/Models/QuickActionRunner.swift
+++ b/Sources/Models/QuickActionRunner.swift
@@ -10,7 +10,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
     case commit
     case push
     case createPR
-    case abandonPR
+    case closePR
 
     var id: String {
         rawValue
@@ -21,7 +21,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
         case .commit: return NSLocalizedString("Commit", comment: "")
         case .push: return NSLocalizedString("Push", comment: "")
         case .createPR: return NSLocalizedString("Create PR", comment: "")
-        case .abandonPR: return NSLocalizedString("Abandon PR", comment: "")
+        case .closePR: return NSLocalizedString("Close PR", comment: "")
         }
     }
 
@@ -30,7 +30,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
         case .commit: return "checkmark.circle"
         case .push: return "arrow.up"
         case .createPR: return "arrow.triangle.pull"
-        case .abandonPR: return "xmark.circle"
+        case .closePR: return "xmark.circle"
         }
     }
 
@@ -38,13 +38,13 @@ enum QuickAction: String, CaseIterable, Identifiable {
     var usesLLM: Bool {
         switch self {
         case .commit, .createPR: return true
-        case .push, .abandonPR: return false
+        case .push, .closePR: return false
         }
     }
 
     var requiresGitHubRemote: Bool {
         switch self {
-        case .createPR, .abandonPR: return true
+        case .createPR, .closePR: return true
         case .commit, .push: return false
         }
     }
@@ -55,7 +55,7 @@ enum QuickAction: String, CaseIterable, Identifiable {
             return "Stage and commit all changes in the working tree with a good commit message based on the changes. Do not push."
         case .createPR:
             return "Create a pull request for the current changes. Write a clear title and description based on what we've been working on."
-        case .push, .abandonPR:
+        case .push, .closePR:
             return nil
         }
     }
@@ -103,9 +103,9 @@ final class QuickActionRunner: ObservableObject {
             runClaudeAction(action: action, claudePath: claudePath, workingDirectory: workingDirectory)
         case .push:
             runPush(workingDirectory: workingDirectory)
-        case .abandonPR:
+        case .closePR:
             guard let ghPath, let branchName else { return }
-            runAbandonPR(ghPath: ghPath, branchName: branchName, workingDirectory: workingDirectory)
+            runClosePR(ghPath: ghPath, branchName: branchName, workingDirectory: workingDirectory)
         }
     }
 
@@ -150,11 +150,11 @@ final class QuickActionRunner: ObservableObject {
         }
     }
 
-    private func runAbandonPR(ghPath: String, branchName: String, workingDirectory: String) {
-        let command = "\(ghPath) pr close \(branchName) --comment 'Abandoned from Factory Floor'"
+    private func runClosePR(ghPath: String, branchName: String, workingDirectory: String) {
+        let command = "\(ghPath) pr close \(branchName) --comment 'Closed from Factory Floor'"
 
-        appendLog(action: .abandonPR, command: command)
-        logger.info("Quick action abandonPR starting in \(workingDirectory)")
+        appendLog(action: .closePR, command: command)
+        logger.info("Quick action closePR starting in \(workingDirectory)")
 
         let dir = workingDirectory
         let path = ghPath
@@ -163,7 +163,7 @@ final class QuickActionRunner: ObservableObject {
             let process = Process()
             let pipe = Pipe()
             process.executableURL = URL(fileURLWithPath: path)
-            process.arguments = ["pr", "close", branch, "--comment", "Abandoned from Factory Floor"]
+            process.arguments = ["pr", "close", branch, "--comment", "Closed from Factory Floor"]
             process.currentDirectoryURL = URL(fileURLWithPath: dir)
             process.standardOutput = pipe
             process.standardError = pipe
@@ -182,9 +182,9 @@ final class QuickActionRunner: ObservableObject {
             await MainActor.run {
                 self.updateLog(output: output, exitCode: success ? 0 : 1)
                 self.runningProcess = nil
-                self.state = success ? .succeeded(.abandonPR) : .failed(.abandonPR)
+                self.state = success ? .succeeded(.closePR) : .failed(.closePR)
                 if success {
-                    self.onSuccess?(.abandonPR)
+                    self.onSuccess?(.closePR)
                 }
                 self.scheduleDismiss()
             }

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -758,7 +758,7 @@ struct TerminalContainerView: View {
                         }
                         .help("New Browser (\u{2318}B)")
 
-                        QuickActionButtons(
+                        GitHubActionMenu(
                             runner: quickActionRunner,
                             claudePath: appEnv.toolStatus.claude.path,
                             ghPath: appEnv.toolStatus.gh.path,
@@ -767,7 +767,7 @@ struct TerminalContainerView: View {
                             bypassPermissions: bypassPermissions,
                             worktreeState: appEnv.worktreeState(for: workingDirectory),
                             hasGitHubRemote: appEnv.hasGitHubRemote(projectDirectory),
-                            prState: branchPR?.state
+                            branchPR: branchPR
                         )
                     }
                 }
@@ -909,10 +909,10 @@ struct TerminalContainerView: View {
         quickActionRunner.onSuccess = { action in
             appEnv.refreshWorktreeState(for: workingDirectory, projectDirectory: projectDirectory)
             if let branch = appEnv.branchName(for: workingDirectory) {
-                if action == .abandonPR {
+                if action == .closePR {
                     appEnv.clearBranchPR(for: projectDirectory, branch: branch)
                 }
-                if action == .createPR || action == .abandonPR {
+                if action == .createPR || action == .closePR {
                     appEnv.refreshGitHubInfo(for: projectDirectory, branch: branch)
                 }
             }
@@ -1141,7 +1141,7 @@ private struct WorkspaceTabDropDelegate: DropDelegate {
     }
 }
 
-private struct QuickActionButtons: View {
+private struct GitHubActionMenu: View {
     @ObservedObject var runner: QuickActionRunner
     let claudePath: String?
     let ghPath: String?
@@ -1150,38 +1150,73 @@ private struct QuickActionButtons: View {
     let bypassPermissions: Bool
     let worktreeState: WorktreeState
     let hasGitHubRemote: Bool
-    let prState: String?
+    let branchPR: GitHubPR?
+
+    private var prState: String? {
+        branchPR?.state
+    }
 
     private var hasOpenPR: Bool {
         prState == "OPEN"
     }
 
-    private func isVisible(_ action: QuickAction) -> Bool {
-        switch action {
-        case .commit:
-            return worktreeState.hasUncommittedChanges
-        case .push:
-            return worktreeState.hasUnpushedCommits && worktreeState.hasRemote
-        case .createPR:
-            return hasGitHubRemote && worktreeState.hasBranchCommits && prState == nil
-        case .abandonPR:
-            return hasOpenPR
-        }
+    private var isMerged: Bool {
+        prState == "MERGED"
     }
 
-    private func disabledReason(for action: QuickAction) -> String? {
-        if action.usesLLM {
-            if claudePath == nil {
-                return NSLocalizedString("Claude Code is not installed.", comment: "")
+    /// The most relevant next action to move the workflow forward.
+    private var primaryAction: PrimaryAction? {
+        if isMerged {
+            return nil
+        }
+        if hasOpenPR {
+            if worktreeState.hasUncommittedChanges {
+                return .quickAction(.commit)
             }
-            if !bypassPermissions {
-                return NSLocalizedString("Enable \"Bypass permission prompts\" in Settings.", comment: "")
+            if worktreeState.hasUnpushedCommits, worktreeState.hasRemote {
+                return .quickAction(.push)
+            }
+            if let pr = branchPR {
+                return .openPR(pr)
             }
         }
-        if action == .abandonPR, ghPath == nil {
-            return NSLocalizedString("gh CLI is not installed.", comment: "")
+        if prState == nil, hasGitHubRemote, worktreeState.hasBranchCommits {
+            return .quickAction(.createPR)
+        }
+        if worktreeState.hasUncommittedChanges {
+            return .quickAction(.commit)
+        }
+        if worktreeState.hasUnpushedCommits, worktreeState.hasRemote {
+            return .quickAction(.push)
         }
         return nil
+    }
+
+    /// Secondary actions shown in the dropdown, excluding the primary.
+    private var secondaryActions: [PrimaryAction] {
+        guard let primary = primaryAction else { return [] }
+        var actions: [PrimaryAction] = []
+
+        if worktreeState.hasUncommittedChanges {
+            actions.append(.quickAction(.commit))
+        }
+        if worktreeState.hasUnpushedCommits, worktreeState.hasRemote {
+            actions.append(.quickAction(.push))
+        }
+        if prState == nil, hasGitHubRemote, worktreeState.hasBranchCommits {
+            actions.append(.quickAction(.createPR))
+        }
+        if let pr = branchPR, hasOpenPR {
+            actions.append(.openPR(pr))
+            actions.append(.quickAction(.closePR))
+        }
+
+        return actions.filter { $0 != primary }
+    }
+
+    private var isRunning: Bool {
+        if case .running = runner.state { return true }
+        return false
     }
 
     private func isRunningAction(_ action: QuickAction) -> Bool {
@@ -1197,18 +1232,19 @@ private struct QuickActionButtons: View {
         }
     }
 
-    var body: some View {
-        ForEach(QuickAction.allCases) { action in
-            if isVisible(action) {
-                QuickActionButton(
-                    action: action,
-                    isRunning: isRunningAction(action),
-                    resultState: resultState(for: action),
-                    disabledReason: disabledReason(for: action),
-                    onRun: { runAction(action) }
-                )
+    private func disabledReason(for action: QuickAction) -> String? {
+        if action.usesLLM {
+            if claudePath == nil {
+                return NSLocalizedString("Claude Code is not installed.", comment: "")
+            }
+            if !bypassPermissions {
+                return NSLocalizedString("Enable \"Bypass permission prompts\" in Settings.", comment: "")
             }
         }
+        if action == .closePR, ghPath == nil {
+            return NSLocalizedString("gh CLI is not installed.", comment: "")
+        }
+        return nil
     }
 
     private func runAction(_ action: QuickAction) {
@@ -1221,40 +1257,116 @@ private struct QuickActionButtons: View {
             branchName: branchName
         )
     }
-}
 
-private struct QuickActionButton: View {
-    let action: QuickAction
-    let isRunning: Bool
-    let resultState: QuickActionState?
-    let disabledReason: String?
-    let onRun: () -> Void
-
-    private var isDisabled: Bool {
-        disabledReason != nil || isRunning
+    private func executePrimary(_ action: PrimaryAction) {
+        guard !isRunning else { return }
+        switch action {
+        case let .quickAction(qa):
+            runAction(qa)
+        case let .openPR(pr):
+            if let url = URL(string: pr.url) {
+                NSWorkspace.shared.open(url)
+            }
+        }
     }
 
-    var body: some View {
-        Button(action: onRun) {
-            if isRunning {
+    @ViewBuilder
+    private func label(for action: PrimaryAction) -> some View {
+        switch action {
+        case let .quickAction(qa):
+            if isRunningAction(qa) {
                 ProgressView()
                     .controlSize(.mini)
-            } else if case .succeeded = resultState {
-                Label(action.label, systemImage: "checkmark.circle.fill")
+            } else if case .succeeded = resultState(for: qa) {
+                Label(qa.label, systemImage: "checkmark.circle.fill")
                     .labelStyle(.titleAndIcon)
                     .foregroundStyle(.green)
-            } else if case .failed = resultState {
-                Label(action.label, systemImage: "xmark.circle.fill")
+            } else if case .failed = resultState(for: qa) {
+                Label(qa.label, systemImage: "xmark.circle.fill")
                     .labelStyle(.titleAndIcon)
                     .foregroundStyle(.red)
             } else {
-                Label(action.label, systemImage: action.icon)
+                Label(qa.label, systemImage: qa.icon)
                     .labelStyle(.titleAndIcon)
             }
+        case let .openPR(pr):
+            Label(
+                String(format: NSLocalizedString("Open #%d", comment: ""), pr.number),
+                systemImage: "arrow.up.forward"
+            )
+            .labelStyle(.titleAndIcon)
         }
-        .disabled(isDisabled)
-        .help(disabledReason ?? action.label)
-        .accessibilityLabel(action.label)
+    }
+
+    var body: some View {
+        if let primary = primaryAction {
+            let secondary = secondaryActions
+            if secondary.isEmpty {
+                Button { executePrimary(primary) } label: { label(for: primary) }
+                    .disabled(isRunning || primaryDisabled(primary))
+                    .help(primaryHelp(primary))
+            } else {
+                Menu {
+                    ForEach(secondary) { action in
+                        switch action {
+                        case let .quickAction(qa):
+                            Button { runAction(qa) } label: {
+                                Label(qa.label, systemImage: qa.icon)
+                            }
+                            .disabled(isRunning || disabledReason(for: qa) != nil)
+                        case let .openPR(pr):
+                            Button {
+                                if let url = URL(string: pr.url) {
+                                    NSWorkspace.shared.open(url)
+                                }
+                            } label: {
+                                Label(
+                                    String(format: NSLocalizedString("Open #%d", comment: ""), pr.number),
+                                    systemImage: "arrow.up.forward"
+                                )
+                            }
+                        }
+                    }
+                } label: {
+                    label(for: primary)
+                } primaryAction: {
+                    executePrimary(primary)
+                }
+                .disabled(isRunning)
+                .menuIndicator(.hidden)
+                .help(primaryHelp(primary))
+            }
+        }
+    }
+
+    private func primaryDisabled(_ action: PrimaryAction) -> Bool {
+        if case let .quickAction(qa) = action {
+            return disabledReason(for: qa) != nil
+        }
+        return false
+    }
+
+    private func primaryHelp(_ action: PrimaryAction) -> String {
+        if case let .quickAction(qa) = action {
+            return disabledReason(for: qa) ?? qa.label
+        }
+        if case let .openPR(pr) = action {
+            return pr.title
+        }
+        return ""
+    }
+}
+
+/// Represents either a quick action or opening a PR in the browser.
+private enum PrimaryAction: Equatable, Identifiable {
+    case quickAction(QuickAction)
+    case openPR(GitHubPR)
+
+    var id: String {
+        switch self {
+        case let .quickAction(qa): return qa.id
+        case let .openPR(pr): return "openPR-\(pr.number)"
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces separate toolbar buttons (Commit, Push, Create PR, Abandon PR) with a single contextual dropdown button that shows the most relevant next action as its primary label
- The dropdown adapts based on workflow state: dirty working dir shows "Commit", unpushed commits shows "Push", open PR with everything pushed shows "Open #N", no PR yet shows "Create PR"
- Renames "Abandon PR" to "Close PR" throughout codebase and all 5 locale files (en, ca, de, es, sv)
- Adds "Open #N" action to view PRs in the browser directly from the dropdown
- When an action is running, shows a spinner and disables the entire menu
- Secondary actions are available in the dropdown menu, including Close PR when a PR is open

## Test plan

- [ ] Verify dropdown shows "Commit" as primary when working directory is dirty and PR is open
- [ ] Verify dropdown shows "Push" as primary when there are unpushed commits and PR is open
- [ ] Verify dropdown shows "Open #N" as primary when PR is open and everything is pushed
- [ ] Verify dropdown shows "Create PR" as primary when no PR exists but branch has commits
- [ ] Verify "Close PR" appears in dropdown menu when PR is open
- [ ] Verify spinner shows during action execution and menu is disabled
- [ ] Verify localized strings display correctly in non-English locales

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)