### PR TITLE
feat: add activity indicators and compact sidebar layout

### DIFF
--- a/Sources/Models/WorkstreamActivityTracker.swift
+++ b/Sources/Models/WorkstreamActivityTracker.swift
@@ -1,0 +1,59 @@
+// ABOUTME: Tracks which workstreams have recent terminal output activity.
+// ABOUTME: Publishes a set of active workstream IDs for use by the sidebar.
+
+import Combine
+import Foundation
+
+@MainActor
+final class WorkstreamActivityTracker: ObservableObject {
+    @Published private(set) var activeWorkstreamIDs: Set<UUID> = []
+
+    /// How long after the last activity a workstream is considered active.
+    private let activityTimeout: TimeInterval = 5
+
+    private var lastActivityTimes: [UUID: Date] = [:]
+    private var cancellables: Set<AnyCancellable> = []
+    private var pruneTimer: AnyCancellable?
+
+    init() {
+        NotificationCenter.default.publisher(for: .terminalTitleChanged)
+            .compactMap { $0.object as? UUID }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] wsID in
+                self?.recordActivity(for: wsID)
+            }
+            .store(in: &cancellables)
+
+        pruneTimer = Timer.publish(every: 2, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.pruneExpired()
+            }
+    }
+
+    private func recordActivity(for workstreamID: UUID) {
+        lastActivityTimes[workstreamID] = Date()
+        if !activeWorkstreamIDs.contains(workstreamID) {
+            activeWorkstreamIDs.insert(workstreamID)
+        }
+    }
+
+    private func pruneExpired() {
+        let cutoff = Date().addingTimeInterval(-activityTimeout)
+        var changed = false
+        for (id, time) in lastActivityTimes where time < cutoff {
+            lastActivityTimes.removeValue(forKey: id)
+            if activeWorkstreamIDs.remove(id) != nil {
+                changed = true
+            }
+        }
+        // Force publish even if the Set reference didn't change
+        if changed {
+            objectWillChange.send()
+        }
+    }
+
+    func isActive(_ workstreamID: UUID) -> Bool {
+        activeWorkstreamIDs.contains(workstreamID)
+    }
+}

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -87,6 +87,7 @@ struct ContentView: View {
     @StateObject private var surfaceCache = TerminalSurfaceCache()
     @StateObject private var appEnvironment = AppEnvironment()
     @StateObject private var updateChecker = UpdateChecker()
+    @StateObject private var activityTracker = WorkstreamActivityTracker()
     @EnvironmentObject private var updater: Updater
     @State private var saveWork: DispatchWorkItem?
     @State private var workstreamToRemove: UUID?
@@ -353,6 +354,7 @@ struct ContentView: View {
         .environmentObject(appEnvironment)
         .environmentObject(updateChecker)
         .environmentObject(updater)
+        .environmentObject(activityTracker)
         .onAppear {
             appEnvironment.refresh()
             appEnvironment.refreshAllRepoInfo(projects: projects)

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -144,6 +144,7 @@ struct ProjectSidebar: View {
                         branchName: branch,
                         worktreePath: workstream.worktreePath,
                         isPathValid: appEnv.isPathValid(workstream.worktreePath),
+                        isActive: activityTracker.isActive(workstream.id),
                         hasActivePort: appEnv.hasActivePort(workstream.id),
                         githubURL: appEnv.githubURL(for: project.directory),
                         taskDescription: appEnv.taskDescription(for: workstream.worktreePath),
@@ -154,7 +155,7 @@ struct ProjectSidebar: View {
                         onPurge: { confirmPurge(workstream) }
                     )
                     .tag(SidebarSelection.workstream(workstream.id))
-                    .padding(.leading, 34)
+                    .padding(.leading, 28)
                 }
             }
         }
@@ -463,6 +464,7 @@ struct ProjectSidebar: View {
     @EnvironmentObject private var appEnv: AppEnvironment
     @EnvironmentObject private var updateChecker: UpdateChecker
     @EnvironmentObject private var updater: Updater
+    @EnvironmentObject private var activityTracker: WorkstreamActivityTracker
 
     private func confirmPurge(_ workstream: Workstream) {
         purgeWarningMessage = WorkstreamArchiver.purgeWarning(for: workstream)
@@ -665,16 +667,16 @@ private struct ProjectHeaderRow: View {
             }
             .frame(width: 22)
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 4) {
                     Text(project.name)
-                        .font(.system(.body, weight: .medium))
+                        .font(.system(size: 13, weight: .medium))
 
                     if !project.workstreams.isEmpty {
                         Text("\(project.workstreams.count)")
-                            .font(.system(size: 10, weight: .medium))
+                            .font(.system(size: 9, weight: .medium))
                             .foregroundStyle(.secondary)
-                            .padding(.horizontal, 5)
+                            .padding(.horizontal, 4)
                             .padding(.vertical, 1)
                             .background(.quaternary)
                             .clipShape(Capsule())
@@ -683,7 +685,7 @@ private struct ProjectHeaderRow: View {
                 }
 
                 Text(project.directory.abbreviatedPath)
-                    .font(.caption)
+                    .font(.system(size: 10))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -709,7 +711,7 @@ private struct ProjectHeaderRow: View {
             .opacity(isHovering ? 1 : 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 2)
+        .padding(.vertical, 1)
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .contextMenu {
@@ -745,6 +747,7 @@ private struct WorkstreamRow: View {
     var branchName: String?
     var worktreePath: String?
     let isPathValid: Bool
+    var isActive: Bool = false
     var hasActivePort: Bool = false
     var githubURL: URL?
     var taskDescription: String?
@@ -778,23 +781,19 @@ private struct WorkstreamRow: View {
     }
 
     var body: some View {
-        HStack {
-            if !isPathValid {
-                Image(systemName: "exclamationmark.triangle")
-                    .foregroundStyle(.orange)
-                    .font(.system(size: 12))
-            }
+        HStack(spacing: 4) {
+            ActivityIndicator(isActive: isActive, isPathValid: isPathValid)
 
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 4) {
                     Text(headline)
-                        .font(.system(.body))
+                        .font(.system(size: 12))
                         .strikethrough(!isPathValid)
                         .foregroundStyle(isPathValid ? .primary : .secondary)
                         .lineLimit(1)
                     if hasActivePort {
                         Image(systemName: "circle.fill")
-                            .font(.system(size: 6))
+                            .font(.system(size: 5))
                             .foregroundStyle(.green)
                     }
                 }
@@ -808,7 +807,7 @@ private struct WorkstreamRow: View {
                         Text(subtitle)
                             .lineLimit(1)
                     }
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: 9, design: .monospaced))
                     .foregroundStyle(prState == "MERGED" ? AnyShapeStyle(.purple) : AnyShapeStyle(.tertiary))
                 }
             }
@@ -868,6 +867,38 @@ private struct WorkstreamRow: View {
                 Label("Purge", systemImage: "trash")
             }
         }
+    }
+}
+
+private struct ActivityIndicator: View {
+    let isActive: Bool
+    let isPathValid: Bool
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        Group {
+            if !isPathValid {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 10))
+            } else if isActive {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 6, height: 6)
+                    .opacity(isPulsing ? 0.4 : 1.0)
+                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: isPulsing)
+                    .onAppear { isPulsing = true }
+                    .onChange(of: isActive) { _, active in
+                        isPulsing = active
+                    }
+            } else {
+                Circle()
+                    .fill(.tertiary)
+                    .frame(width: 6, height: 6)
+            }
+        }
+        .frame(width: 12)
     }
 }
 

--- a/Tests/WorkstreamActivityTrackerTests.swift
+++ b/Tests/WorkstreamActivityTrackerTests.swift
@@ -1,0 +1,50 @@
+// ABOUTME: Tests for WorkstreamActivityTracker.
+// ABOUTME: Validates activity tracking, expiration, and query behavior.
+
+@testable import FactoryFloor
+import XCTest
+
+@MainActor
+final class WorkstreamActivityTrackerTests: XCTestCase {
+    func testInitiallyNoActiveWorkstreams() {
+        let tracker = WorkstreamActivityTracker()
+        XCTAssertTrue(tracker.activeWorkstreamIDs.isEmpty)
+    }
+
+    func testIsActiveReturnsFalseForUnknownID() {
+        let tracker = WorkstreamActivityTracker()
+        XCTAssertFalse(tracker.isActive(UUID()))
+    }
+
+    func testBecomesActiveOnTitleChange() {
+        let tracker = WorkstreamActivityTracker()
+        let wsID = UUID()
+
+        NotificationCenter.default.post(
+            name: .terminalTitleChanged,
+            object: wsID,
+            userInfo: ["title": "working..."]
+        )
+
+        // Run the main run loop briefly to process the notification
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        XCTAssertTrue(tracker.isActive(wsID))
+        XCTAssertTrue(tracker.activeWorkstreamIDs.contains(wsID))
+    }
+
+    func testMultipleWorkstreamsCanBeActive() {
+        let tracker = WorkstreamActivityTracker()
+        let ws1 = UUID()
+        let ws2 = UUID()
+
+        NotificationCenter.default.post(name: .terminalTitleChanged, object: ws1, userInfo: ["title": "a"])
+        NotificationCenter.default.post(name: .terminalTitleChanged, object: ws2, userInfo: ["title": "b"])
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        XCTAssertTrue(tracker.isActive(ws1))
+        XCTAssertTrue(tracker.isActive(ws2))
+        XCTAssertEqual(tracker.activeWorkstreamIDs.count, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- Add pulsing green activity indicators next to workstreams with active terminal output (uses terminal title change events as the activity signal, with a 5-second timeout)
- Show static gray dots for idle workstreams, and warning icons for invalid paths
- Make sidebar more compact: reduce font sizes, spacing, and padding for project headers and workstream rows

Closes #399

## Test plan
- [ ] Verify activity indicators pulse when a workstream's terminal is actively producing output
- [ ] Verify indicators go static after ~5 seconds of inactivity
- [ ] Verify invalid path warning icon still appears for broken workstreams
- [ ] Verify sidebar is visibly more compact while remaining readable
- [ ] Verify active port green dot still appears alongside activity indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)