### PR TITLE
feat: reorganize workspace tabs with Info as first tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Breaking changes: add `!` after the type or include `BREAKING CHANGE:` in the fo
 
 ### Workstream lifecycle
 1. Creating a workstream: generates name, runs `git worktree add`, symlinks .env (if enabled)
-2. Workspace view: Agent tab always present, terminals/browsers added on demand
+2. Workspace view: Info (Cmd+1) and Agent (Cmd+2) tabs always present; terminals/browsers added on demand
 3. Tmux mode: wraps Coding Agent only in `tmux new-session -A` on socket `-L factoryfloor`
 4. Terminal tabs: close on shell exit (Ctrl+D). Agent respawns.
 5. Archiving: runs teardown script, then `git worktree remove` + `tmux kill-session`
@@ -167,7 +167,9 @@ When adding, removing, or changing keyboard shortcuts:
 5. Update website shortcuts section
 
 Current shortcuts:
-- **Cmd+1-9**: Switch tab (all tabs in display order)
+- **Cmd+1**: Info
+- **Cmd+2**: Coding Agent
+- **Cmd+3-9**: Switch tab (all tabs in display order)
 - **Cmd+Shift+[/]**: Cycle tabs
 - **Cmd+Return**: Focus Coding Agent
 - **Cmd+T**: New Terminal

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ Every workstream terminal has access to:
 
 | Shortcut | Action |
 |---|---|
-| `Cmd+1-9` | Switch tab |
+| `Cmd+1` | Info |
+| `Cmd+2` | Coding Agent |
+| `Cmd+3-9` | Switch tab |
 | `Cmd+Shift+[` / `]` | Cycle tabs |
 | `Cmd+Return` | Focus Coding Agent |
 | `Cmd+T` | New Terminal |

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -142,8 +142,7 @@ struct ContentView: View {
                 let scriptConfig = ScriptConfig.load(from: project.directory)
                 let initialTabState = startupWorkspaceTabState(
                     snapshot: surfaceCache.restoreTabSnapshot(for: workstreamID),
-                    savedTab: WorkspaceStateStore.load(for: workstreamID),
-                    hasEnvironmentTab: scriptConfig.run != nil
+                    savedTab: WorkspaceStateStore.load(for: workstreamID)
                 )
                 TerminalContainerView(
                     workstreamID: workstreamID,

--- a/Sources/Views/HelpView.swift
+++ b/Sources/Views/HelpView.swift
@@ -86,7 +86,9 @@ struct HelpView: View {
                     }
 
                     Section {
-                        ShortcutRow(keys: "1-9", description: "Switch tab")
+                        ShortcutRow(keys: "1", description: "Info")
+                        ShortcutRow(keys: "2", description: "Coding Agent")
+                        ShortcutRow(keys: "3-9", description: "Switch tab")
                         ShortcutRow(keys: "[", shift: true, description: "Previous tab")
                         ShortcutRow(keys: "]", shift: true, description: "Next tab")
                         ShortcutRow(keys: "Return", description: "Focus Coding Agent")

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -16,7 +16,6 @@ extension Notification.Name {
     static let closeTerminal = Notification.Name("factoryfloor.closeTerminal")
     static let nextTab = Notification.Name("factoryfloor.nextTab")
     static let prevTab = Notification.Name("factoryfloor.prevTab")
-    static let toggleEnvironment = Notification.Name("factoryfloor.toggleEnvironment")
     static let terminalTitleChanged = Notification.Name("factoryfloor.terminalTitleChanged")
 }
 
@@ -29,21 +28,17 @@ enum RestorableWorkspaceTab: String, Codable {
         switch activeTab {
         case .agent:
             self = .agent
-        case .environment:
-            self = .environment
         case .info, .terminal, .browser:
             self = .info
         }
     }
 
-    func workspaceTab(hasEnvironmentTab: Bool) -> WorkspaceTab {
+    func workspaceTab() -> WorkspaceTab {
         switch self {
-        case .info:
+        case .info, .environment:
             return .info
         case .agent:
             return .agent
-        case .environment:
-            return hasEnvironmentTab ? .environment : .info
         }
     }
 }
@@ -124,13 +119,12 @@ func reorderedCustomTabs(_ tabs: [WorkspaceTab], dragging draggedTab: WorkspaceT
 enum WorkspaceTab: Hashable {
     case info
     case agent
-    case environment
     case terminal(UUID)
     case browser(UUID)
 
     var isCloseable: Bool {
         switch self {
-        case .info, .agent, .environment: return false
+        case .info, .agent: return false
         case .terminal, .browser: return true
         }
     }
@@ -170,23 +164,30 @@ struct WorkspaceTabSnapshot {
     }
 }
 
-func startupWorkspaceTabState(snapshot: WorkspaceTabSnapshot?, savedTab: RestorableWorkspaceTab?, hasEnvironmentTab: Bool) -> WorkspaceTabSnapshot {
-    if var snapshot {
-        if hasEnvironmentTab && !snapshot.tabs.contains(.environment) {
-            snapshot.tabs.insert(.environment, at: min(2, snapshot.tabs.count))
+func startupWorkspaceTabState(snapshot: WorkspaceTabSnapshot?, savedTab: RestorableWorkspaceTab?) -> WorkspaceTabSnapshot {
+    if let snapshot {
+        // Filter out any persisted environment tabs from before the merge
+        let filteredTabs = snapshot.tabs.filter { tab in
+            if case .info = tab { return true }
+            if case .agent = tab { return true }
+            if case .terminal = tab { return true }
+            if case .browser = tab { return true }
+            return false
         }
-        return snapshot
+        var cleaned = snapshot
+        cleaned.tabs = filteredTabs
+        if !cleaned.tabs.contains(cleaned.activeTab) {
+            cleaned.activeTab = .info
+        }
+        return cleaned
     }
 
-    var tabs: [WorkspaceTab] = [.info, .agent]
-    if hasEnvironmentTab {
-        tabs.append(.environment)
-    }
+    let tabs: [WorkspaceTab] = [.info, .agent]
     return WorkspaceTabSnapshot(
         tabs: tabs,
         terminalCount: 0,
         browserCount: 0,
-        activeTab: (savedTab ?? .info).workspaceTab(hasEnvironmentTab: hasEnvironmentTab),
+        activeTab: (savedTab ?? .info).workspaceTab(),
         browserTitles: [:],
         terminalTitles: [:],
         runStarted: false,
@@ -284,7 +285,7 @@ struct TerminalContainerView: View {
         bypassPermissions: Bool,
         isActive: Bool,
         scriptConfig: ScriptConfig = .empty,
-        initialTabState: WorkspaceTabSnapshot = startupWorkspaceTabState(snapshot: nil, savedTab: nil, hasEnvironmentTab: false)
+        initialTabState: WorkspaceTabSnapshot = startupWorkspaceTabState(snapshot: nil, savedTab: nil)
     ) {
         self.workstreamID = workstreamID
         self.workingDirectory = workingDirectory
@@ -318,7 +319,6 @@ struct TerminalContainerView: View {
     }
 
     /// Surface IDs that should be rendering for the active tab.
-    /// Returns nil for the environment tab (env surface IDs are managed internally).
     private var visibleSurfaceIDs: Set<UUID>? {
         switch activeTab {
         case .agent:
@@ -328,7 +328,6 @@ struct TerminalContainerView: View {
             return [claudeID]
         case let .terminal(id): return [id]
         case .info, .browser: return []
-        case .environment: return nil
         }
     }
 
@@ -455,7 +454,7 @@ struct TerminalContainerView: View {
 
     private var tabBar: some View {
         HStack(spacing: 0) {
-            // Fixed tabs (Info, Agent, Environment)
+            // Fixed tabs (Info, Agent)
             ForEach(fixedTabs, id: \.self) { tab in
                 tabButton(for: tab)
             }
@@ -468,6 +467,13 @@ struct TerminalContainerView: View {
                     tabButton: { tab in tabButton(for: tab) }
                 )
             }
+
+            // Quick actions to add tabs
+            HStack(spacing: 2) {
+                TabBarActionButton(icon: "terminal", tooltip: "New Terminal (\u{2318}T)", action: addTerminal)
+                TabBarActionButton(icon: "globe", tooltip: "New Browser (\u{2318}B)", action: addBrowser)
+            }
+            .padding(.leading, 4)
 
             Spacer()
 
@@ -534,7 +540,12 @@ struct TerminalContainerView: View {
                 workingDirectory: workingDirectory,
                 projectName: projectName,
                 projectDirectory: projectDirectory,
-                scriptConfig: scriptConfig
+                scriptConfig: scriptConfig,
+                useTmux: useTmux,
+                environmentVars: terminalEnvVars,
+                runStoppedManually: $runStoppedManually,
+                runStarted: $runStarted,
+                sessionMode: sessionMode
             )
         case .agent:
             if setupGateState == .running {
@@ -568,22 +579,6 @@ struct TerminalContainerView: View {
             } else {
                 terminalLoadingView(message: "Preparing Coding Agent...")
             }
-        case .environment:
-            if sessionMode == .waitingForTools {
-                terminalLoadingView(message: "Checking terminal tools...")
-            } else {
-                EnvironmentTabView(
-                    workstreamID: workstreamID,
-                    workingDirectory: workingDirectory,
-                    projectName: projectName,
-                    workstreamName: workstreamName,
-                    scriptConfig: scriptConfig,
-                    useTmux: useTmux,
-                    environmentVars: terminalEnvVars,
-                    runStoppedManually: $runStoppedManually,
-                    runStarted: $runStarted
-                )
-            }
         case let .terminal(id):
             SingleTerminalView(
                 surfaceID: id,
@@ -616,13 +611,9 @@ struct TerminalContainerView: View {
                 guard isActive else { return }
                 activeTab = .agent
             }
-            .onReceive(NotificationCenter.default.publisher(for: .toggleEnvironment)) { _ in
-                guard isActive else { return }
-                if tabs.contains(.environment) { activeTab = .environment }
-            }
             .onReceive(NotificationCenter.default.publisher(for: .rerunScript)) { _ in
                 guard isActive else { return }
-                if tabs.contains(.environment) { activeTab = .environment }
+                activeTab = .info
             }
             .onReceive(NotificationCenter.default.publisher(for: .toggleTerminal)) { _ in
                 guard isActive else { return }
@@ -746,18 +737,6 @@ struct TerminalContainerView: View {
                             .help("Open on GitHub")
                         }
 
-                        Button(action: addTerminal) {
-                            Label(NSLocalizedString("Terminal", comment: ""), systemImage: "terminal")
-                                .labelStyle(.titleAndIcon)
-                        }
-                        .help("New Terminal (\u{2318}T)")
-
-                        Button(action: addBrowser) {
-                            Label(NSLocalizedString("Browser", comment: ""), systemImage: "globe")
-                                .labelStyle(.titleAndIcon)
-                        }
-                        .help("New Browser (\u{2318}B)")
-
                         GitHubActionMenu(
                             runner: quickActionRunner,
                             claudePath: appEnv.toolStatus.claude.path,
@@ -794,7 +773,6 @@ struct TerminalContainerView: View {
         switch tab {
         case .info: return NSLocalizedString("Info", comment: "")
         case .agent: return NSLocalizedString("Agent", comment: "")
-        case .environment: return NSLocalizedString("Environment", comment: "")
         case .terminal:
             return nil
         case let .browser(id):
@@ -808,7 +786,6 @@ struct TerminalContainerView: View {
         switch tab {
         case .info: return "info.circle"
         case .agent: return "sparkle"
-        case .environment: return "gearshape.2"
         case .terminal: return "terminal"
         case .browser: return "globe"
         }
@@ -836,8 +813,6 @@ struct TerminalContainerView: View {
             return "info"
         case .agent:
             return "agent"
-        case .environment:
-            return "environment"
         }
     }
 
@@ -963,15 +938,6 @@ struct TerminalContainerView: View {
     private func buildSetupGateCommand() -> String? {
         guard let setup = scriptConfig.setup else { return nil }
         return scriptCommand(script: setup, role: "setup")
-    }
-
-    private func buildEnvironmentCommand(script: String, role: String) -> String {
-        let command = scriptCommand(script: script, role: role)
-        if useTmux, let tmuxPath = appEnv.toolStatus.tmux.path {
-            let session = TmuxSession.sessionName(project: projectName, workstream: workstreamName, role: role)
-            return TmuxSession.wrapCommand(tmuxPath: tmuxPath, sessionName: session, command: command, environmentVars: terminalEnvVars)
-        }
-        return command
     }
 
     /// Env vars for plain terminal tabs. Clears tmux vars to prevent inheritance.
@@ -1125,6 +1091,28 @@ private struct WorkspaceTabButton: View {
         .contentShape(Rectangle())
         .onTapGesture(perform: onSelect)
         .onHover { isHovering = $0 }
+    }
+}
+
+private struct TabBarActionButton: View {
+    let icon: String
+    let tooltip: String
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundStyle(isHovering ? .primary : .tertiary)
+                .frame(width: 24, height: 24)
+                .background(isHovering ? Color.primary.opacity(0.08) : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.borderless)
+        .onHover { isHovering = $0 }
+        .help(tooltip)
     }
 }
 

--- a/Sources/Views/WorkstreamInfoView.swift
+++ b/Sources/Views/WorkstreamInfoView.swift
@@ -1,5 +1,5 @@
-// ABOUTME: Info panel for a workstream showing app branding, metadata, shortcuts, and docs.
-// ABOUTME: Default view when opening a workstream, dismissible with Cmd+Return.
+// ABOUTME: Info panel for a workstream showing metadata, environment, and docs.
+// ABOUTME: First tab in the workspace, combining project info with run script controls.
 
 import SwiftUI
 
@@ -10,6 +10,11 @@ struct WorkstreamInfoView: View {
     let projectName: String
     let projectDirectory: String
     var scriptConfig: ScriptConfig = .empty
+    var useTmux: Bool = false
+    var environmentVars: [String: String] = [:]
+    @Binding var runStoppedManually: Bool
+    @Binding var runStarted: Bool
+    var sessionMode: TerminalSessionMode = .standard
 
     @EnvironmentObject var appEnv: AppEnvironment
     @AppStorage("factoryfloor.defaultTerminal") private var defaultTerminal: String = ""
@@ -188,13 +193,40 @@ struct WorkstreamInfoView: View {
             }
             .formStyle(.grouped)
 
-            // Markdown content fills remaining space when a doc is selected
-            if let selected = selectedDoc,
-               let doc = docFiles.first(where: { $0.name == selected })
-            {
+            // Environment (run script) section
+            if scriptConfig.run != nil || scriptConfig.loadError != nil {
                 Divider()
-                MarkdownContentView(markdown: doc.content)
-                    .id(selected)
+                if sessionMode == .waitingForTools {
+                    VStack(spacing: 12) {
+                        ProgressView()
+                            .controlSize(.regular)
+                        Text("Checking terminal tools...")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    EnvironmentTabView(
+                        workstreamID: workstreamID,
+                        workingDirectory: workingDirectory,
+                        projectName: projectName,
+                        workstreamName: workstreamName,
+                        scriptConfig: scriptConfig,
+                        useTmux: useTmux,
+                        environmentVars: environmentVars,
+                        runStoppedManually: $runStoppedManually,
+                        runStarted: $runStarted
+                    )
+                }
+            } else {
+                // Markdown content fills remaining space when a doc is selected
+                if let selected = selectedDoc,
+                   let doc = docFiles.first(where: { $0.name == selected })
+                {
+                    Divider()
+                    MarkdownContentView(markdown: doc.content)
+                        .id(selected)
+                }
             }
 
             // Doc tabs pinned to bottom

--- a/Tests/WorkspaceTabStateTests.swift
+++ b/Tests/WorkspaceTabStateTests.swift
@@ -115,7 +115,7 @@ final class WorkspaceTabSnapshotTests: XCTestCase {
         XCTAssertEqual(reconciled.activeTab, .browser(browserID))
     }
 
-    func testStartupStateAddsEnvironmentTabToRestoredSnapshot() {
+    func testStartupStatePreservesRestoredSnapshot() {
         let snapshot = WorkspaceTabSnapshot(
             tabs: [.info, .agent],
             terminalCount: 0,
@@ -129,11 +129,10 @@ final class WorkspaceTabSnapshotTests: XCTestCase {
 
         let state = startupWorkspaceTabState(
             snapshot: snapshot,
-            savedTab: nil,
-            hasEnvironmentTab: true
+            savedTab: nil
         )
 
-        XCTAssertEqual(state.tabs, [.info, .agent, .environment])
+        XCTAssertEqual(state.tabs, [.info, .agent])
         XCTAssertEqual(state.activeTab, .agent)
         XCTAssertTrue(state.runStarted)
     }
@@ -141,8 +140,7 @@ final class WorkspaceTabSnapshotTests: XCTestCase {
     func testStartupStateUsesSavedFixedTabWithoutSnapshot() {
         let state = startupWorkspaceTabState(
             snapshot: nil,
-            savedTab: .agent,
-            hasEnvironmentTab: false
+            savedTab: .agent
         )
 
         XCTAssertEqual(state.tabs, [.info, .agent])
@@ -204,20 +202,19 @@ final class WorkspaceTabStateTests: XCTestCase {
         XCTAssertEqual(RestorableWorkspaceTab(activeTab: .browser(UUID())), .info)
     }
 
-    func testEnvironmentRestoresToInfoWhenUnavailable() {
-        XCTAssertEqual(RestorableWorkspaceTab.environment.workspaceTab(hasEnvironmentTab: false), .info)
-        XCTAssertEqual(RestorableWorkspaceTab.environment.workspaceTab(hasEnvironmentTab: true), .environment)
+    func testEnvironmentRestoresToInfo() {
+        XCTAssertEqual(RestorableWorkspaceTab.environment.workspaceTab(), .info)
     }
 
     func testReorderedCustomTabsKeepsFixedTabsInPlace() throws {
         let terminalA = try WorkspaceTab.terminal(XCTUnwrap(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")))
         let browserB = try WorkspaceTab.browser(XCTUnwrap(UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")))
         let terminalC = try WorkspaceTab.terminal(XCTUnwrap(UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")))
-        let tabs: [WorkspaceTab] = [.info, .agent, .environment, terminalA, browserB, terminalC]
+        let tabs: [WorkspaceTab] = [.info, .agent, terminalA, browserB, terminalC]
 
         let reordered = reorderedCustomTabs(tabs, dragging: terminalC, to: terminalA)
 
-        XCTAssertEqual(reordered, [.info, .agent, .environment, terminalC, terminalA, browserB])
+        XCTAssertEqual(reordered, [.info, .agent, terminalC, terminalA, browserB])
     }
 
     func testRenderableWorkstreamIDKeepsOnlySelectedReadyWorkstream() throws {

--- a/website/content/ca/docs.md
+++ b/website/content/ca/docs.md
@@ -116,7 +116,7 @@ Els terminals es renderitzen per GPU via [Ghostty](https://ghostty.org). Són r�
 
 - **⌘T** — nou terminal tab
 - **⌘W** — tanca tab (o Ctrl+D per sortir del shell)
-- **⌘1-9** — canvia entre tabs
+- **⌘1** — Info, **⌘2** — Coding Agent, **⌘3-9** — canvia entre tabs
 - **⌘Shift+[** / **⌘Shift+]** — cicla entre tabs
 
 Pots arrossegar fitxers i text sobre el terminal. Perquè de vegades el ratolí està bé, la veritat.
@@ -157,7 +157,9 @@ Factory Floor prioritza el teclat. Aquí tens tot.
 
 | Drecera | Acció |
 |----------|--------|
-| ⌘1-9 | Canvia de tab |
+| ⌘1 | Info |
+| ⌘2 | Coding Agent |
+| ⌘3-9 | Canvia de tab |
 | ⌘Shift+[ | Tab anterior |
 | ⌘Shift+] | Tab següent |
 | ⌘Return | Focus Coding Agent |

--- a/website/content/de/docs.md
+++ b/website/content/de/docs.md
@@ -116,7 +116,7 @@ Terminals werden GPU-gerendert über [Ghostty](https://ghostty.org). Sie sind sc
 
 - **⌘T** — neuer Terminal-Tab
 - **⌘W** — Tab schließen (oder Ctrl+D zum Beenden der Shell)
-- **⌘1-9** — zwischen Tabs wechseln
+- **⌘1** — Info, **⌘2** — Coding Agent, **⌘3-9** — zwischen Tabs wechseln
 - **⌘Shift+[** / **⌘Shift+]** — durch Tabs blättern
 
 Du kannst Dateien und Text auf das Terminal ziehen. Weil manchmal die Maus völlig in Ordnung ist, ehrlich.
@@ -157,7 +157,9 @@ Factory Floor ist tastaturorientiert. Hier ist alles.
 
 | Kürzel | Aktion |
 |----------|--------|
-| ⌘1-9 | Tab wechseln |
+| ⌘1 | Info |
+| ⌘2 | Coding Agent |
+| ⌘3-9 | Tab wechseln |
 | ⌘Shift+[ | Vorheriger Tab |
 | ⌘Shift+] | Nächster Tab |
 | ⌘Return | Coding-Agent fokussieren |

--- a/website/content/docs.md
+++ b/website/content/docs.md
@@ -116,7 +116,7 @@ Terminals are GPU-rendered via [Ghostty](https://ghostty.org). They're fast.
 
 - **⌘T** — new terminal tab
 - **⌘W** — close tab (or Ctrl+D to exit the shell)
-- **⌘1-9** — switch between tabs
+- **⌘1** — Info, **⌘2** — Coding Agent, **⌘3-9** — switch between tabs
 - **⌘Shift+[** / **⌘Shift+]** — cycle through tabs
 
 You can drag files and text onto the terminal. Because sometimes the mouse is fine, actually.
@@ -157,7 +157,9 @@ Factory Floor is keyboard-first. Here's everything.
 
 | Shortcut | Action |
 |----------|--------|
-| ⌘1-9 | Switch tab |
+| ⌘1 | Info |
+| ⌘2 | Coding Agent |
+| ⌘3-9 | Switch tab |
 | ⌘Shift+[ | Previous tab |
 | ⌘Shift+] | Next tab |
 | ⌘Return | Focus Coding Agent |

--- a/website/content/es/docs.md
+++ b/website/content/es/docs.md
@@ -116,7 +116,7 @@ Los terminals se renderizan por GPU con [Ghostty](https://ghostty.org). Son ráp
 
 - **⌘T** — nuevo terminal tab
 - **⌘W** — cerrar tab (o Ctrl+D para salir del shell)
-- **⌘1-9** — cambiar entre tabs
+- **⌘1** — Info, **⌘2** — Coding Agent, **⌘3-9** — cambiar entre tabs
 - **⌘Shift+[** / **⌘Shift+]** — recorrer tabs
 
 Puedes arrastrar archivos y texto al terminal. Porque a veces el ratón está bien, la verdad.
@@ -157,7 +157,9 @@ Factory Floor prioriza el teclado. Aquí está todo.
 
 | Atajo | Acción |
 |----------|--------|
-| ⌘1-9 | Cambiar tab |
+| ⌘1 | Info |
+| ⌘2 | Coding Agent |
+| ⌘3-9 | Cambiar tab |
 | ⌘Shift+[ | Tab anterior |
 | ⌘Shift+] | Tab siguiente |
 | ⌘Return | Foco en Coding Agent |

--- a/website/content/sv/docs.md
+++ b/website/content/sv/docs.md
@@ -116,7 +116,7 @@ Terminals är GPU-renderade via [Ghostty](https://ghostty.org). De är snabba.
 
 - **⌘T** — ny terminal tab
 - **⌘W** — stäng tab (eller Ctrl+D för att avsluta shell)
-- **⌘1-9** — växla mellan tabs
+- **⌘1** — Info, **⌘2** — Coding Agent, **⌘3-9** — växla mellan tabs
 - **⌘Shift+[** / **⌘Shift+]** — bläddra genom tabs
 
 Du kan dra filer och text till terminal. För ibland är musen helt okej, faktiskt.
@@ -157,7 +157,9 @@ Factory Floor är tangentbord-först. Här är allt.
 
 | Genväg | Åtgärd |
 |----------|--------|
-| ⌘1-9 | Byt tab |
+| ⌘1 | Info |
+| ⌘2 | Coding Agent |
+| ⌘3-9 | Byt tab |
 | ⌘Shift+[ | Föregående tab |
 | ⌘Shift+] | Nästa tab |
 | ⌘Return | Fokusera Coding Agent |

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -72,7 +72,7 @@ Workstream:
 - `Cmd+W` — close tab
 - `Cmd+L` — address bar (browser)
 - `Cmd+0` — back to project
-- `Cmd+1-9` — switch tab
+- `Cmd+1` — Info, `Cmd+2` — Coding Agent, `Cmd+3-9` — switch tab
 - `Ctrl+1-9` — switch workstream
 - `Cmd+Shift+[` / `]` — cycle tabs
 - `Ctrl+Shift+R` — rebuild setup


### PR DESCRIPTION
## Summary
- Merge Info and Environment tabs into a single Info tab that shows project metadata, docs, and run script controls
- Reorder tabs: Info (Cmd+1), Agent (Cmd+2), then closeable tabs (Cmd+3-9)
- Move Terminal/Browser add buttons from the toolbar into the tab bar as compact quick actions after the tab strip
- Update keyboard shortcut documentation in all 5 places (FF2App.swift, HelpView.swift, README.md, CLAUDE.md, website docs)
- Update all 5 locales (en, ca, de, es, sv)

Closes #400

## Test plan
- [x] All 180 existing tests pass
- [ ] Verify Info tab shows project metadata and run script controls
- [ ] Verify Cmd+1 opens Info, Cmd+2 opens Agent
- [ ] Verify + Terminal and + Browser buttons appear after tab strip
- [ ] Verify tab cycling (Cmd+Shift+[/]) works correctly with new tab order

🤖 Generated with [Claude Code](https://claude.com/claude-code)