### PR TITLE
feat: credit contributors in release changelog entries

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,6 +6,7 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "include-commit-authors": true,
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary
- Enables `include-commit-authors: true` in `.release-please-config.json`
- Each changelog entry will now include the PR author's GitHub handle (e.g. `(@username)`)
- Flows automatically into CHANGELOG.md, GitHub releases, and the website changelog

## Test plan
- [ ] Verify the next release-please PR includes `(@username)` on changelog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)