### PR TITLE
fix(ci): build Monaco editor before xcodegen in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           version: ${{ env.SPARKLE_VERSION }}
 
+      - name: Build Monaco editor
+        run: ./scripts/build-editor.sh
+
       - name: Generate Xcode project
         run: xcodegen generate
 


### PR DESCRIPTION
## Summary
- The release workflow was failing because `xcodegen generate` runs before `Resources/MonacoEditor` exists
- Added a `Build Monaco editor` step (runs `build-editor.sh`) before the xcodegen step

## Test plan
- [ ] Re-run the release workflow and confirm it passes the "Generate Xcode project" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)