### PR TITLE
fix(ci): increase Node heap size for Monaco editor build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           version: ${{ env.SPARKLE_VERSION }}
 
+      - name: Build Monaco editor
+        run: ./scripts/build-editor.sh
+
       - name: Generate Xcode project
         run: xcodegen generate
 

--- a/scripts/build-editor.sh
+++ b/scripts/build-editor.sh
@@ -38,7 +38,7 @@ if needs_rebuild; then
   echo "Building Monaco editor bundle..."
   cd "$EDITOR_DIR"
   bun install --frozen-lockfile 2>&1
-  bunx vite build 2>&1
+  NODE_OPTIONS="--max-old-space-size=4096" bunx vite build 2>&1
   echo "Monaco editor built to Resources/MonacoEditor/"
 else
   echo "Monaco editor bundle is up to date, skipping build."


### PR DESCRIPTION
## Summary
- v0.1.69 build failed with V8 OOM during `bunx vite build` (Monaco editor bundle exceeds default 2GB heap)
- Set `NODE_OPTIONS="--max-old-space-size=4096"` in `build-editor.sh`
- Also deleted the empty v0.1.69 release (tag preserved)

## Test plan
- [ ] Next release-please cycle should build the Monaco editor without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)