### PR TITLE
feat: show cumulative changelog in update popover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,9 @@ jobs:
               print(m.group(1).strip())
           " | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
 
+          # Download existing appcast to merge with (preserves history)
+          gh release download --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output existing-appcast.xml || true
+
           DMG_URL="https://github.com/alltuner/factoryfloor/releases/download/v${VERSION}/${DMG_NAME}"
           python3 scripts/generate_appcast.py \
             --version "$VERSION" \
@@ -278,6 +281,7 @@ jobs:
             --dmg-path "build/release/$DMG_NAME" \
             --dmg-url "$DMG_URL" \
             --release-notes "$RELEASE_NOTES" \
+            --existing existing-appcast.xml \
             --output appcast.xml
 
       - name: Upload to release

--- a/Sources/Models/UpdateChecker.swift
+++ b/Sources/Models/UpdateChecker.swift
@@ -4,15 +4,23 @@
 import Foundation
 import os
 
-struct AppcastInfo {
+struct AppcastRelease {
     let version: String
     let releaseNotesURL: URL?
+    let releaseNotes: String?
 }
 
 @MainActor
 class UpdateChecker: ObservableObject {
-    @Published var availableVersion: String?
-    @Published var releaseNotesURL: URL?
+    @Published var pendingReleases: [AppcastRelease] = []
+
+    var availableVersion: String? {
+        pendingReleases.first?.version
+    }
+
+    var releaseNotesURL: URL? {
+        pendingReleases.first?.releaseNotesURL
+    }
 
     private let currentVersion: String
     private let logger = Logger(subsystem: AppConstants.appID, category: "UpdateChecker")
@@ -29,12 +37,11 @@ class UpdateChecker: ObservableObject {
             Task.detached { [currentVersion, logger] in
                 do {
                     let (data, _) = try await URLSession.shared.data(from: Self.appcastURL)
-                    guard let info = Self.parseAppcast(from: data) else { return }
-                    if Self.isNewer(info.version, than: currentVersion) {
-                        await MainActor.run { [weak self] in
-                            self?.availableVersion = info.version
-                            self?.releaseNotesURL = info.releaseNotesURL
-                        }
+                    let releases = Self.parseAppcast(from: data)
+                    let pending = Self.releasesNewer(than: currentVersion, in: releases)
+                    guard !pending.isEmpty else { return }
+                    await MainActor.run { [weak self] in
+                        self?.pendingReleases = pending
                     }
                 } catch {
                     logger.debug("Update check failed: \(error.localizedDescription)")
@@ -43,18 +50,23 @@ class UpdateChecker: ObservableObject {
         #endif
     }
 
-    /// Extracts version and release notes URL from the first item in an appcast feed.
-    nonisolated static func parseAppcast(from data: Data) -> AppcastInfo? {
+    /// Parses all release items from an appcast feed, ordered newest first.
+    nonisolated static func parseAppcast(from data: Data) -> [AppcastRelease] {
         let parser = AppcastParser()
         let xmlParser = XMLParser(data: data)
         xmlParser.delegate = parser
-        guard xmlParser.parse(), let version = parser.version else { return nil }
-        return AppcastInfo(version: version, releaseNotesURL: parser.releaseNotesURL)
+        guard xmlParser.parse() else { return [] }
+        return parser.releases
     }
 
     /// Extracts the sparkle:shortVersionString from the first enclosure in an appcast feed.
     nonisolated static func parseVersion(from data: Data) -> String? {
-        parseAppcast(from: data)?.version
+        parseAppcast(from: data).first?.version
+    }
+
+    /// Filters releases to those newer than the given version.
+    nonisolated static func releasesNewer(than version: String, in releases: [AppcastRelease]) -> [AppcastRelease] {
+        releases.filter { isNewer($0.version, than: version) }
     }
 
     /// Simple semver comparison: returns true if `remote` is newer than `local`.
@@ -72,12 +84,15 @@ class UpdateChecker: ObservableObject {
 }
 
 private class AppcastParser: NSObject, XMLParserDelegate {
-    var version: String?
-    var releaseNotesURL: URL?
+    var releases: [AppcastRelease] = []
 
     private var insideItem = false
     private var currentElement: String?
     private var currentText = ""
+
+    private var itemVersion: String?
+    private var itemLink: URL?
+    private var itemDescription: String?
 
     func parser(
         _: XMLParser,
@@ -88,8 +103,11 @@ private class AppcastParser: NSObject, XMLParserDelegate {
     ) {
         if elementName == "item" {
             insideItem = true
-        } else if elementName == "enclosure", version == nil {
-            version = attributeDict["sparkle:shortVersionString"]
+            itemVersion = nil
+            itemLink = nil
+            itemDescription = nil
+        } else if elementName == "enclosure", insideItem, itemVersion == nil {
+            itemVersion = attributeDict["sparkle:shortVersionString"]
         }
         currentElement = elementName
         currentText = ""
@@ -105,11 +123,24 @@ private class AppcastParser: NSObject, XMLParserDelegate {
         namespaceURI _: String?,
         qualifiedName _: String?
     ) {
-        if elementName == "link", insideItem, releaseNotesURL == nil {
+        if insideItem {
             let trimmed = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
-            releaseNotesURL = URL(string: trimmed)
-        } else if elementName == "item" {
-            insideItem = false
+            if elementName == "link" {
+                itemLink = URL(string: trimmed)
+            } else if elementName == "description" {
+                if !trimmed.isEmpty {
+                    itemDescription = trimmed
+                }
+            } else if elementName == "item" {
+                if let version = itemVersion {
+                    releases.append(AppcastRelease(
+                        version: version,
+                        releaseNotesURL: itemLink,
+                        releaseNotes: itemDescription
+                    ))
+                }
+                insideItem = false
+            }
         }
         currentElement = nil
     }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -164,7 +164,11 @@ struct ProjectSidebar: View {
     private var bottomBar: some View {
         VStack(spacing: 4) {
             if let version = updateChecker.availableVersion {
-                UpdateBanner(version: version, releaseNotesURL: updateChecker.releaseNotesURL, updater: updater)
+                UpdateBanner(
+                    version: version,
+                    pendingReleases: updateChecker.pendingReleases,
+                    updater: updater
+                )
             }
 
             // Credit

--- a/Sources/Views/UpdateBannerView.swift
+++ b/Sources/Views/UpdateBannerView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct UpdateBanner: View {
     let version: String
-    let releaseNotesURL: URL?
+    let pendingReleases: [AppcastRelease]
     @ObservedObject var updater: Updater
 
     @State private var isHovering = false
@@ -34,23 +34,26 @@ struct UpdateBanner: View {
         .buttonStyle(.borderless)
         .onHover { isHovering = $0 }
         .popover(isPresented: $showBrewPopover, arrowEdge: .top) {
-            BrewUpdatePopover(version: version, releaseNotesURL: releaseNotesURL)
+            BrewUpdatePopover(pendingReleases: pendingReleases)
         }
     }
 }
 
 private struct BrewUpdatePopover: View {
-    let version: String
-    let releaseNotesURL: URL?
+    let pendingReleases: [AppcastRelease]
 
     @State private var copied = false
 
     private static let brewCommand = "brew upgrade factory-floor"
 
+    private var latestVersion: String {
+        pendingReleases.first?.version ?? ""
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Label {
-                Text("v\(version) available")
+                Text("v\(latestVersion) available")
                     .fontWeight(.semibold)
             } icon: {
                 Image(systemName: "arrow.up.circle.fill")
@@ -89,18 +92,75 @@ private struct BrewUpdatePopover: View {
                     .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
             )
 
-            if let url = releaseNotesURL {
-                Link(destination: url) {
-                    HStack(spacing: 4) {
-                        Text("Release Notes")
-                            .font(.system(size: 11))
+            if !pendingReleases.isEmpty {
+                Divider()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(Array(pendingReleases.enumerated()), id: \.offset) { _, release in
+                            ReleaseEntryView(release: release)
+                        }
+                    }
+                }
+                .frame(maxHeight: 300)
+            }
+        }
+        .padding(12)
+        .frame(width: 320)
+    }
+}
+
+private struct ReleaseEntryView: View {
+    let release: AppcastRelease
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("v\(release.version)")
+                    .font(.system(size: 12, weight: .semibold))
+
+                Spacer()
+
+                if let url = release.releaseNotesURL {
+                    Link(destination: url) {
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 9))
                     }
                 }
             }
+
+            if let notes = release.releaseNotes {
+                ReleaseNotesText(html: notes)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
         }
-        .padding(12)
-        .frame(width: 260)
+    }
+}
+
+private struct ReleaseNotesText: View {
+    let html: String
+
+    var body: some View {
+        if let attributed = renderHTML(html) {
+            Text(attributed)
+        } else {
+            Text(html)
+        }
+    }
+
+    private func renderHTML(_ html: String) -> AttributedString? {
+        let wrapped = "<style>body { font-family: -apple-system; font-size: 11px; }</style>\(html)"
+        guard let data = wrapped.data(using: .utf8),
+              let nsAttr = try? NSAttributedString(
+                  data: data,
+                  options: [
+                      .documentType: NSAttributedString.DocumentType.html,
+                      .characterEncoding: String.Encoding.utf8.rawValue,
+                  ],
+                  documentAttributes: nil
+              )
+        else { return nil }
+        return try? AttributedString(nsAttr, including: \.swiftUI)
     }
 }

--- a/Tests/UpdateCheckerTests.swift
+++ b/Tests/UpdateCheckerTests.swift
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for parsing the latest version from a Sparkle appcast XML feed.
-// ABOUTME: Covers valid appcast, missing version, and malformed XML scenarios.
+// ABOUTME: Tests for parsing versions and release notes from a Sparkle appcast XML feed.
+// ABOUTME: Covers single-item, multi-item, version filtering, and malformed XML scenarios.
 
 @testable import FactoryFloor
 import XCTest
@@ -59,9 +59,10 @@ final class UpdateCheckerTests: XCTestCase {
           </channel>
         </rss>
         """
-        let result = UpdateChecker.parseAppcast(from: Data(xml.utf8))
-        XCTAssertEqual(result?.version, "0.2.0")
-        XCTAssertEqual(result?.releaseNotesURL, URL(string: "https://factory-floor.com/changelog/0.2.0"))
+        let releases = UpdateChecker.parseAppcast(from: Data(xml.utf8))
+        XCTAssertEqual(releases.count, 1)
+        XCTAssertEqual(releases[0].version, "0.2.0")
+        XCTAssertEqual(releases[0].releaseNotesURL, URL(string: "https://factory-floor.com/changelog/0.2.0"))
     }
 
     func testParsesAppcastWithoutReleaseNotesURL() {
@@ -80,9 +81,107 @@ final class UpdateCheckerTests: XCTestCase {
           </channel>
         </rss>
         """
-        let result = UpdateChecker.parseAppcast(from: Data(xml.utf8))
-        XCTAssertEqual(result?.version, "0.2.0")
-        XCTAssertNil(result?.releaseNotesURL)
+        let releases = UpdateChecker.parseAppcast(from: Data(xml.utf8))
+        XCTAssertEqual(releases.count, 1)
+        XCTAssertEqual(releases[0].version, "0.2.0")
+        XCTAssertNil(releases[0].releaseNotesURL)
+    }
+
+    func testParsesMultipleItemsFromAppcast() {
+        let xml = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>Version 0.3.0</title>
+              <link>https://github.com/alltuner/factoryfloor/releases/tag/v0.3.0</link>
+              <description>&lt;p&gt;Added feature X&lt;/p&gt;</description>
+              <enclosure url="https://example.com/app-0.3.0.dmg"
+                         sparkle:version="0.3.0"
+                         sparkle:shortVersionString="0.3.0"
+                         length="2000"
+                         type="application/octet-stream" />
+            </item>
+            <item>
+              <title>Version 0.2.0</title>
+              <link>https://github.com/alltuner/factoryfloor/releases/tag/v0.2.0</link>
+              <description>&lt;p&gt;Fixed bug Y&lt;/p&gt;</description>
+              <enclosure url="https://example.com/app-0.2.0.dmg"
+                         sparkle:version="0.2.0"
+                         sparkle:shortVersionString="0.2.0"
+                         length="1500"
+                         type="application/octet-stream" />
+            </item>
+            <item>
+              <title>Version 0.1.0</title>
+              <enclosure url="https://example.com/app-0.1.0.dmg"
+                         sparkle:version="0.1.0"
+                         sparkle:shortVersionString="0.1.0"
+                         length="1000"
+                         type="application/octet-stream" />
+            </item>
+          </channel>
+        </rss>
+        """
+        let releases = UpdateChecker.parseAppcast(from: Data(xml.utf8))
+        XCTAssertEqual(releases.count, 3)
+
+        XCTAssertEqual(releases[0].version, "0.3.0")
+        XCTAssertEqual(releases[0].releaseNotes, "<p>Added feature X</p>")
+        XCTAssertEqual(
+            releases[0].releaseNotesURL,
+            URL(string: "https://github.com/alltuner/factoryfloor/releases/tag/v0.3.0")
+        )
+
+        XCTAssertEqual(releases[1].version, "0.2.0")
+        XCTAssertEqual(releases[1].releaseNotes, "<p>Fixed bug Y</p>")
+
+        XCTAssertEqual(releases[2].version, "0.1.0")
+        XCTAssertNil(releases[2].releaseNotes)
+        XCTAssertNil(releases[2].releaseNotesURL)
+    }
+
+    func testParsesDescriptionAsReleaseNotes() {
+        let xml = """
+        <?xml version='1.0' encoding='utf-8'?>
+        <rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item>
+              <title>Version 0.2.0</title>
+              <description>&lt;h3&gt;Bug Fixes&lt;/h3&gt;&lt;ul&gt;&lt;li&gt;Fixed crash&lt;/li&gt;&lt;/ul&gt;</description>
+              <enclosure url="https://example.com/app.dmg"
+                         sparkle:version="0.2.0"
+                         sparkle:shortVersionString="0.2.0"
+                         length="1000"
+                         type="application/octet-stream" />
+            </item>
+          </channel>
+        </rss>
+        """
+        let releases = UpdateChecker.parseAppcast(from: Data(xml.utf8))
+        XCTAssertEqual(releases.count, 1)
+        XCTAssertEqual(releases[0].releaseNotes, "<h3>Bug Fixes</h3><ul><li>Fixed crash</li></ul>")
+    }
+
+    func testReleasesNewerThanFiltersCorrectly() {
+        let releases = [
+            AppcastRelease(version: "0.3.0", releaseNotesURL: nil, releaseNotes: "Three"),
+            AppcastRelease(version: "0.2.0", releaseNotesURL: nil, releaseNotes: "Two"),
+            AppcastRelease(version: "0.1.5", releaseNotesURL: nil, releaseNotes: "One-five"),
+            AppcastRelease(version: "0.1.0", releaseNotesURL: nil, releaseNotes: "One"),
+        ]
+        let pending = UpdateChecker.releasesNewer(than: "0.1.5", in: releases)
+        XCTAssertEqual(pending.count, 2)
+        XCTAssertEqual(pending[0].version, "0.3.0")
+        XCTAssertEqual(pending[1].version, "0.2.0")
+    }
+
+    func testReleasesNewerThanReturnsEmptyWhenUpToDate() {
+        let releases = [
+            AppcastRelease(version: "0.2.0", releaseNotesURL: nil, releaseNotes: nil),
+        ]
+        let pending = UpdateChecker.releasesNewer(than: "0.2.0", in: releases)
+        XCTAssertTrue(pending.isEmpty)
     }
 
     func testIsNewerComparison() {

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -1,10 +1,62 @@
 #!/usr/bin/env python3
+# ABOUTME: Generates a Sparkle appcast.xml from release metadata and DMG signature.
+# ABOUTME: Merges with existing appcast to accumulate changelog history across releases.
 """Generate a Sparkle appcast.xml from release metadata and DMG signature."""
 
 import argparse
 import datetime
 import os
 import xml.etree.ElementTree as ET
+
+
+def build_item(
+    version: str,
+    signature: str,
+    dmg_length: int,
+    dmg_url: str,
+    min_os: str = "14.0",
+    release_notes: str | None = None,
+) -> ET.Element:
+    """Build a single appcast <item> element."""
+    item = ET.Element("item")
+    ET.SubElement(item, "title").text = f"Version {version}"
+    ET.SubElement(
+        item, "link"
+    ).text = f"https://github.com/alltuner/factoryfloor/releases/tag/v{version}"
+    pub_date = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%a, %d %b %Y %H:%M:%S %z"
+    )
+    ET.SubElement(item, "pubDate").text = pub_date
+    ns = f"{{{SPARKLE_NS}}}"
+    ET.SubElement(item, f"{ns}minimumSystemVersion").text = min_os
+
+    if release_notes:
+        ET.SubElement(item, "description").text = release_notes
+
+    enclosure = ET.SubElement(item, "enclosure")
+    enclosure.set("url", dmg_url)
+    enclosure.set(f"{ns}version", version)
+    enclosure.set(f"{ns}shortVersionString", version)
+    enclosure.set(f"{ns}edSignature", signature)
+    enclosure.set("length", str(dmg_length))
+    enclosure.set("type", "application/octet-stream")
+
+    return item
+
+
+SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
+ET.register_namespace("sparkle", SPARKLE_NS)
+
+
+def parse_existing_items(existing_path: str) -> list[ET.Element]:
+    """Parse existing appcast XML and return its <item> elements."""
+    if not os.path.exists(existing_path):
+        return []
+    try:
+        tree = ET.parse(existing_path)
+        return list(tree.findall(".//item"))
+    except ET.ParseError:
+        return []
 
 
 def build_appcast(
@@ -14,10 +66,10 @@ def build_appcast(
     dmg_url: str,
     min_os: str = "14.0",
     release_notes: str | None = None,
+    existing_path: str | None = None,
 ) -> str:
     rss = ET.Element("rss")
     rss.set("version", "2.0")
-    rss.set("xmlns:sparkle", "https://www.andymatuschak.org/xml-namespaces/sparkle")
     rss.set("xmlns:dc", "http://purl.org/dc/elements/1.1/")
 
     channel = ET.SubElement(rss, "channel")
@@ -26,27 +78,25 @@ def build_appcast(
     ET.SubElement(channel, "description").text = "Factory Floor updates"
     ET.SubElement(channel, "language").text = "en"
 
-    item = ET.SubElement(channel, "item")
-    ET.SubElement(item, "title").text = f"Version {version}"
-    ET.SubElement(
-        item, "link"
-    ).text = f"https://github.com/alltuner/factoryfloor/releases/tag/v{version}"
-    pub_date = datetime.datetime.now(datetime.timezone.utc).strftime(
-        "%a, %d %b %Y %H:%M:%S %z"
+    new_item = build_item(
+        version=version,
+        signature=signature,
+        dmg_length=dmg_length,
+        dmg_url=dmg_url,
+        min_os=min_os,
+        release_notes=release_notes,
     )
-    ET.SubElement(item, "pubDate").text = pub_date
-    ET.SubElement(item, "sparkle:minimumSystemVersion").text = min_os
+    channel.append(new_item)
 
-    if release_notes:
-        ET.SubElement(item, "description").text = release_notes
-
-    enclosure = ET.SubElement(item, "enclosure")
-    enclosure.set("url", dmg_url)
-    enclosure.set("sparkle:version", version)
-    enclosure.set("sparkle:shortVersionString", version)
-    enclosure.set("sparkle:edSignature", signature)
-    enclosure.set("length", str(dmg_length))
-    enclosure.set("type", "application/octet-stream")
+    # Append previous items, skipping any with the same version
+    version_attr = f"{{{SPARKLE_NS}}}shortVersionString"
+    for old_item in (parse_existing_items(existing_path) if existing_path else []):
+        enclosure = old_item.find("enclosure")
+        if enclosure is not None:
+            old_version = enclosure.get(version_attr, "")
+            if old_version == version:
+                continue
+        channel.append(old_item)
 
     ET.indent(rss, space="  ")
     xml_str = ET.tostring(rss, encoding="unicode", xml_declaration=True)
@@ -60,6 +110,7 @@ def main() -> None:
     parser.add_argument("--dmg-path", required=True, help="Path to the DMG file")
     parser.add_argument("--dmg-url", required=True, help="Download URL for the DMG")
     parser.add_argument("--release-notes", default=None, help="Release notes HTML to embed")
+    parser.add_argument("--existing", default=None, help="Path to existing appcast.xml to merge with")
     parser.add_argument("--output", default="appcast.xml", help="Output path")
     args = parser.parse_args()
 
@@ -70,6 +121,7 @@ def main() -> None:
         dmg_length=dmg_length,
         dmg_url=args.dmg_url,
         release_notes=args.release_notes,
+        existing_path=args.existing,
     )
 
     with open(args.output, "w") as f:

--- a/scripts/seed_appcast.py
+++ b/scripts/seed_appcast.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# ABOUTME: Seeds an appcast.xml with historical releases from CHANGELOG.md.
+# ABOUTME: One-time script to populate changelog history before the first accumulating release.
+"""Seed an appcast.xml with historical releases from CHANGELOG.md.
+
+Generates items for all versions found in CHANGELOG.md. These items have
+release notes and links but no enclosure/DMG data (since those releases
+already shipped). The generate_appcast.py script will prepend real items
+with enclosure data on each new release.
+"""
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
+ET.register_namespace("sparkle", SPARKLE_NS)
+
+REPO_URL = "https://github.com/alltuner/factoryfloor"
+
+# Matches "## [0.1.70](...) (2026-04-13)" or "## 0.1.70 (2026-04-13)"
+VERSION_PATTERN = re.compile(
+    r"^## \[?(\d+\.\d+\.\d+)\]?"
+    r"(?:\([^)]*\))?"
+    r"\s*\((\d{4}-\d{2}-\d{2})\)",
+)
+
+
+def parse_changelog(text: str) -> list[dict[str, str]]:
+    """Parse CHANGELOG.md into a list of {version, date, body} dicts."""
+    releases: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    body_lines: list[str] = []
+
+    for line in text.splitlines():
+        match = VERSION_PATTERN.match(line)
+        if match:
+            if current is not None:
+                current["body"] = "\n".join(body_lines).strip()
+                releases.append(current)
+            current = {"version": match.group(1), "date": match.group(2)}
+            body_lines = []
+        elif current is not None:
+            body_lines.append(line)
+
+    if current is not None:
+        current["body"] = "\n".join(body_lines).strip()
+        releases.append(current)
+
+    return releases
+
+
+def clean_body(body: str) -> str:
+    """Strip commit hashes and PR links to keep release notes concise."""
+    # Remove trailing commit hash references like ([abc1234](https://...))
+    body = re.sub(r"\s*\(\[[\da-f]+\]\([^)]+\)\)", "", body)
+    # Remove issue/PR number links like ([#123](https://...))
+    body = re.sub(r"\s*\(\[#\d+\]\([^)]+\)\)", "", body)
+    # Remove standalone issue refs like , closes [#123](...)
+    body = re.sub(r",?\s*closes\s+\[#\d+\]\([^)]+\)", "", body)
+    # Remove empty sections (header followed by blank lines)
+    body = re.sub(r"###\s+\w+\n+(?=###|\Z)", "", body)
+    return body.strip()
+
+
+def markdown_to_html(md: str) -> str:
+    """Minimal markdown to HTML for changelog content."""
+    lines = md.splitlines()
+    html_parts: list[str] = []
+    in_list = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            continue
+        if stripped.startswith("### "):
+            if in_list:
+                html_parts.append("</ul>")
+                in_list = False
+            heading = stripped[4:]
+            html_parts.append(f"<h4>{heading}</h4>")
+        elif stripped.startswith("* "):
+            if not in_list:
+                html_parts.append("<ul>")
+                in_list = True
+            content = stripped[2:]
+            # Bold scope prefix like **ci:**
+            content = re.sub(r"\*\*([^*]+)\*\*", r"<b>\1</b>", content)
+            html_parts.append(f"<li>{content}</li>")
+        else:
+            html_parts.append(f"<p>{stripped}</p>")
+
+    if in_list:
+        html_parts.append("</ul>")
+
+    return "\n".join(html_parts)
+
+
+def build_seed_appcast(changelog_text: str) -> str:
+    """Build an appcast XML with historical releases from CHANGELOG.md."""
+    releases = parse_changelog(changelog_text)
+
+    rss = ET.Element("rss")
+    rss.set("version", "2.0")
+    rss.set("xmlns:dc", "http://purl.org/dc/elements/1.1/")
+
+    channel = ET.SubElement(rss, "channel")
+    ET.SubElement(channel, "title").text = "Factory Floor"
+    ET.SubElement(channel, "link").text = "https://factory-floor.com"
+    ET.SubElement(channel, "description").text = "Factory Floor updates"
+    ET.SubElement(channel, "language").text = "en"
+
+    ns = f"{{{SPARKLE_NS}}}"
+
+    for release in releases:
+        version = release["version"]
+        body = clean_body(release["body"])
+        if not body:
+            continue
+
+        html = markdown_to_html(body)
+
+        item = ET.SubElement(channel, "item")
+        ET.SubElement(item, "title").text = f"Version {version}"
+        ET.SubElement(item, "link").text = f"{REPO_URL}/releases/tag/v{version}"
+        ET.SubElement(item, "description").text = html
+
+        # Enclosure with version info but no DMG data (historical releases)
+        enclosure = ET.SubElement(item, "enclosure")
+        enclosure.set(f"{ns}version", version)
+        enclosure.set(f"{ns}shortVersionString", version)
+
+    ET.indent(rss, space="  ")
+    return ET.tostring(rss, encoding="unicode", xml_declaration=True)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Seed appcast from CHANGELOG.md")
+    parser.add_argument(
+        "--changelog", default="CHANGELOG.md", help="Path to CHANGELOG.md"
+    )
+    parser.add_argument("--output", default="appcast-seed.xml", help="Output path")
+    args = parser.parse_args()
+
+    with open(args.changelog) as f:
+        text = f.read()
+
+    xml = build_seed_appcast(text)
+    with open(args.output, "w") as f:
+        f.write(xml)
+        f.write("\n")
+
+    releases = parse_changelog(text)
+    print(f"Seeded {args.output} with {len(releases)} releases")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_generate_appcast.py
+++ b/scripts/test_generate_appcast.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
+# ABOUTME: Tests for generate_appcast.py.
+# ABOUTME: Covers release notes, HTML entities, existing appcast merging, and deduplication.
 """Tests for generate_appcast.py."""
 
+import tempfile
 import xml.etree.ElementTree as ET
 import sys
 import os
 
 sys.path.insert(0, os.path.dirname(__file__))
-from generate_appcast import build_appcast
+from generate_appcast import build_appcast, SPARKLE_NS
+
+NS = f"{{{SPARKLE_NS}}}"
 
 
 def parse(xml_str: str) -> ET.Element:
@@ -81,6 +86,112 @@ def test_item_contains_release_link() -> None:
     assert link is not None, "Expected <link> element in item"
     assert link.text == "https://github.com/alltuner/factoryfloor/releases/tag/v1.4.0"
     print("PASS: item_contains_release_link")
+
+
+def test_merges_with_existing_appcast() -> None:
+    """New item should be prepended, existing items preserved."""
+    existing = """\
+<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>Version 1.0.0</title>
+      <link>https://github.com/alltuner/factoryfloor/releases/tag/v1.0.0</link>
+      <description>First release</description>
+      <enclosure url="https://example.com/app-1.0.0.dmg"
+                 sparkle:version="1.0.0"
+                 sparkle:shortVersionString="1.0.0"
+                 sparkle:edSignature="oldsig"
+                 length="1000"
+                 type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        f.write(existing)
+        existing_path = f.name
+
+    try:
+        xml = build_appcast(
+            version="1.1.0",
+            signature="newsig",
+            dmg_length=2000,
+            dmg_url="https://example.com/app-1.1.0.dmg",
+            release_notes="Bug fixes",
+            existing_path=existing_path,
+        )
+        root = parse(xml)
+        items = root.findall(".//item")
+        assert len(items) == 2, f"Expected 2 items, got {len(items)}"
+
+        # First item is the new release
+        enc0 = items[0].find("enclosure")
+        assert enc0.get(f"{NS}shortVersionString") == "1.1.0"
+        desc0 = items[0].find("description")
+        assert desc0 is not None and desc0.text == "Bug fixes"
+
+        # Second item is the old release
+        enc1 = items[1].find("enclosure")
+        assert enc1.get(f"{NS}shortVersionString") == "1.0.0"
+        desc1 = items[1].find("description")
+        assert desc1 is not None and desc1.text == "First release"
+    finally:
+        os.unlink(existing_path)
+    print("PASS: merges_with_existing_appcast")
+
+
+def test_deduplicates_same_version() -> None:
+    """Re-releasing the same version should replace the old item, not duplicate it."""
+    existing = """\
+<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>Version 1.0.0</title>
+      <enclosure url="https://example.com/app-1.0.0.dmg"
+                 sparkle:version="1.0.0"
+                 sparkle:shortVersionString="1.0.0"
+                 sparkle:edSignature="oldsig"
+                 length="1000"
+                 type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        f.write(existing)
+        existing_path = f.name
+
+    try:
+        xml = build_appcast(
+            version="1.0.0",
+            signature="newsig",
+            dmg_length=1500,
+            dmg_url="https://example.com/app-1.0.0-fixed.dmg",
+            existing_path=existing_path,
+        )
+        root = parse(xml)
+        items = root.findall(".//item")
+        assert len(items) == 1, f"Expected 1 item (deduplicated), got {len(items)}"
+        enc = items[0].find("enclosure")
+        assert enc.get(f"{NS}edSignature") == "newsig"
+    finally:
+        os.unlink(existing_path)
+    print("PASS: deduplicates_same_version")
+
+
+def test_handles_missing_existing_file() -> None:
+    """When existing file doesn't exist, should produce single-item appcast."""
+    xml = build_appcast(
+        version="1.0.0",
+        signature="sig",
+        dmg_length=1000,
+        dmg_url="https://example.com/app.dmg",
+        existing_path="/nonexistent/appcast.xml",
+    )
+    root = parse(xml)
+    items = root.findall(".//item")
+    assert len(items) == 1, f"Expected 1 item, got {len(items)}"
+    print("PASS: handles_missing_existing_file")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Parse all items from the Sparkle appcast feed instead of just the latest version
- Filter to versions newer than installed and display inline release notes in the Homebrew update popover
- Appcast now accumulates across releases (`generate_appcast.py` merges with existing `appcast.xml` via `--existing` flag)
- Added `seed_appcast.py` to bootstrap changelog history from `CHANGELOG.md` (already uploaded 70-release seed to v0.1.70)

## Test plan
- [x] All 193 Swift tests pass (10 UpdateChecker tests, up from 6)
- [x] All 7 Python generate_appcast tests pass (3 new: merge, dedup, missing file)
- [x] Seed script generates valid appcast from CHANGELOG.md (70 releases)
- [x] Seeded appcast.xml uploaded to v0.1.70 release
- [ ] After merge: trigger website deploy, then verify Sparkle shows cumulative release notes from an old DMG
- [ ] Verify Homebrew popover shows multi-version changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)