### PR TITLE
fix(ci): download appcast from previous release, not latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,8 +271,12 @@ jobs:
               print(m.group(1).strip())
           " | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
 
-          # Download existing appcast to merge with (preserves history)
-          gh release download --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output existing-appcast.xml || true
+          # Download existing appcast from previous release to merge with (preserves history).
+          # Cannot use --latest because release-please already created the current (empty) release.
+          PREV_TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 10 --json tagName --jq "[.[] | select(.tagName != \"$TAG_NAME\")][0].tagName")
+          if [ -n "$PREV_TAG" ]; then
+            gh release download "$PREV_TAG" --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output existing-appcast.xml || true
+          fi
 
           DMG_URL="https://github.com/alltuner/factoryfloor/releases/download/v${VERSION}/${DMG_NAME}"
           python3 scripts/generate_appcast.py \

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -22,7 +22,7 @@ h4 { margin: 8px 0 4px; font-size: 13px; }
 ul { margin: 4px 0; padding-left: 20px; }
 li { margin: 2px 0; }
 hr { border: none; border-top: 1px solid #ddd; margin: 12px 0; }
-.sparkle-installed-version ~ div { display: none; }
+.sparkle-installed-version, .sparkle-installed-version ~ * { display: none; }
 @media (prefers-color-scheme: dark) {
   body { color: #e0e0e0; }
   hr { border-color: #444; }

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -8,14 +8,72 @@ import datetime
 import os
 import xml.etree.ElementTree as ET
 
+SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
+ET.register_namespace("sparkle", SPARKLE_NS)
+
+# CSS injected into the cumulative release notes HTML. Sparkle (2.5+) adds the
+# class "sparkle-installed-version" to the div whose data-sparkle-version matches
+# the user's installed build. The general sibling combinator (~) hides everything
+# older than the installed version.
+RELEASE_NOTES_CSS = """\
+body { font-family: -apple-system, sans-serif; font-size: 13px; line-height: 1.5; padding: 8px 12px; }
+h3 { margin: 12px 0 4px; font-size: 15px; }
+h4 { margin: 8px 0 4px; font-size: 13px; }
+ul { margin: 4px 0; padding-left: 20px; }
+li { margin: 2px 0; }
+hr { border: none; border-top: 1px solid #ddd; margin: 12px 0; }
+.sparkle-installed-version ~ div { display: none; }
+@media (prefers-color-scheme: dark) {
+  body { color: #e0e0e0; }
+  hr { border-color: #444; }
+}"""
+
+
+def build_cumulative_description(
+    current_version: str,
+    current_notes: str | None,
+    existing_items: list[ET.Element],
+) -> str:
+    """Build an HTML description with all versions, tagged with data-sparkle-version."""
+    version_attr = f"{{{SPARKLE_NS}}}shortVersionString"
+    sections: list[str] = []
+
+    if current_notes:
+        sections.append(
+            f'<div data-sparkle-version="{current_version}">'
+            f"<h3>v{current_version}</h3>\n{current_notes}\n</div>"
+        )
+
+    for item in existing_items:
+        enclosure = item.find("enclosure")
+        if enclosure is None:
+            continue
+        version = enclosure.get(version_attr, "")
+        if not version or version == current_version:
+            continue
+        desc = item.find("description")
+        if desc is None or not desc.text or not desc.text.strip():
+            continue
+        sections.append(
+            f'<div data-sparkle-version="{version}">'
+            f"<h3>v{version}</h3>\n{desc.text.strip()}\n</div>"
+        )
+
+    if not sections:
+        return current_notes or ""
+
+    separator = "\n<hr>\n"
+    body = separator.join(sections)
+    return f"<style>{RELEASE_NOTES_CSS}</style>\n{body}"
+
 
 def build_item(
     version: str,
     signature: str,
     dmg_length: int,
     dmg_url: str,
+    description: str,
     min_os: str = "14.0",
-    release_notes: str | None = None,
 ) -> ET.Element:
     """Build a single appcast <item> element."""
     item = ET.Element("item")
@@ -30,8 +88,8 @@ def build_item(
     ns = f"{{{SPARKLE_NS}}}"
     ET.SubElement(item, f"{ns}minimumSystemVersion").text = min_os
 
-    if release_notes:
-        ET.SubElement(item, "description").text = release_notes
+    if description:
+        ET.SubElement(item, "description").text = description
 
     enclosure = ET.SubElement(item, "enclosure")
     enclosure.set("url", dmg_url)
@@ -42,10 +100,6 @@ def build_item(
     enclosure.set("type", "application/octet-stream")
 
     return item
-
-
-SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
-ET.register_namespace("sparkle", SPARKLE_NS)
 
 
 def parse_existing_items(existing_path: str) -> list[ET.Element]:
@@ -68,6 +122,12 @@ def build_appcast(
     release_notes: str | None = None,
     existing_path: str | None = None,
 ) -> str:
+    existing_items = parse_existing_items(existing_path) if existing_path else []
+
+    cumulative_desc = build_cumulative_description(
+        version, release_notes, existing_items
+    )
+
     rss = ET.Element("rss")
     rss.set("version", "2.0")
     rss.set("xmlns:dc", "http://purl.org/dc/elements/1.1/")
@@ -83,14 +143,14 @@ def build_appcast(
         signature=signature,
         dmg_length=dmg_length,
         dmg_url=dmg_url,
+        description=cumulative_desc,
         min_os=min_os,
-        release_notes=release_notes,
     )
     channel.append(new_item)
 
-    # Append previous items, skipping any with the same version
+    # Append previous items (used by the in-app Homebrew update popover)
     version_attr = f"{{{SPARKLE_NS}}}shortVersionString"
-    for old_item in (parse_existing_items(existing_path) if existing_path else []):
+    for old_item in existing_items:
         enclosure = old_item.find("enclosure")
         if enclosure is not None:
             old_version = enclosure.get(version_attr, "")

--- a/scripts/test_generate_appcast.py
+++ b/scripts/test_generate_appcast.py
@@ -124,13 +124,17 @@ def test_merges_with_existing_appcast() -> None:
         items = root.findall(".//item")
         assert len(items) == 2, f"Expected 2 items, got {len(items)}"
 
-        # First item is the new release
+        # First item has cumulative description with both versions
         enc0 = items[0].find("enclosure")
         assert enc0.get(f"{NS}shortVersionString") == "1.1.0"
         desc0 = items[0].find("description")
-        assert desc0 is not None and desc0.text == "Bug fixes"
+        assert desc0 is not None
+        assert "Bug fixes" in desc0.text
+        assert "First release" in desc0.text
+        assert 'data-sparkle-version="1.1.0"' in desc0.text
+        assert 'data-sparkle-version="1.0.0"' in desc0.text
 
-        # Second item is the old release
+        # Second item (old) keeps its own description
         enc1 = items[1].find("enclosure")
         assert enc1.get(f"{NS}shortVersionString") == "1.0.0"
         desc1 = items[1].find("description")
@@ -177,6 +181,62 @@ def test_deduplicates_same_version() -> None:
     finally:
         os.unlink(existing_path)
     print("PASS: deduplicates_same_version")
+
+
+def test_cumulative_description_includes_css_and_version_tags() -> None:
+    """Cumulative description should have CSS for Sparkle version highlighting."""
+    existing = """\
+<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>Version 1.1.0</title>
+      <description>&lt;p&gt;Middle release&lt;/p&gt;</description>
+      <enclosure sparkle:version="1.1.0" sparkle:shortVersionString="1.1.0"
+                 sparkle:edSignature="sig2" length="1500" url="https://example.com/1.1.dmg"
+                 type="application/octet-stream" />
+    </item>
+    <item>
+      <title>Version 1.0.0</title>
+      <description>Initial release</description>
+      <enclosure sparkle:version="1.0.0" sparkle:shortVersionString="1.0.0"
+                 sparkle:edSignature="sig1" length="1000" url="https://example.com/1.0.dmg"
+                 type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        f.write(existing)
+        existing_path = f.name
+
+    try:
+        xml = build_appcast(
+            version="1.2.0",
+            signature="sig3",
+            dmg_length=2000,
+            dmg_url="https://example.com/1.2.dmg",
+            release_notes="<p>Latest stuff</p>",
+            existing_path=existing_path,
+        )
+        root = parse(xml)
+        desc = root.find(".//item/description")
+        assert desc is not None
+
+        # Should contain CSS with sparkle-installed-version rule
+        assert "sparkle-installed-version" in desc.text
+
+        # Should contain all three versions tagged
+        assert 'data-sparkle-version="1.2.0"' in desc.text
+        assert 'data-sparkle-version="1.1.0"' in desc.text
+        assert 'data-sparkle-version="1.0.0"' in desc.text
+
+        # Content from all versions present
+        assert "Latest stuff" in desc.text
+        assert "Middle release" in desc.text
+        assert "Initial release" in desc.text
+    finally:
+        os.unlink(existing_path)
+    print("PASS: cumulative_description_includes_css_and_version_tags")
 
 
 def test_handles_missing_existing_file() -> None:


### PR DESCRIPTION
## Summary
- release-please creates the new (empty) release before the build step runs
- `gh release download` with no tag was downloading from the current release (no appcast.xml yet), so the merge silently failed and produced a single-item appcast
- Fix: find the previous release tag via `gh release list` and download from that

## Test plan
- [x] Manually verified by re-seeding v0.1.71 with combined 71-item appcast
- [ ] Next release should automatically merge with the 71-item appcast from v0.1.71

🤖 Generated with [Claude Code](https://claude.com/claude-code)