### PR TITLE
fix: deduplicate versions and filter noise in Sparkle changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
             exit 1
           fi
 
-          # Extract current version's changelog section and convert to HTML
+          # Extract current version's changelog section, filter noise, and convert to HTML
           RELEASE_NOTES=$(python3 -c "
           import re, sys
           text = open('CHANGELOG.md').read()
@@ -268,7 +268,12 @@ jobs:
           pattern = r'## \[${VERSION}\].*?\n(.*?)(?=\n## \[|\Z)'
           m = re.search(pattern, text, re.DOTALL)
           if m:
-              print(m.group(1).strip())
+              body = m.group(1).strip()
+              # Remove CI and dependency entries (not useful to end users)
+              body = re.sub(r'^\* \*\*(?:ci|deps):\*\*.*\n?', '', body, flags=re.MULTILINE)
+              # Remove sections left empty after filtering
+              body = re.sub(r'### [^\n]+\n+(?=### |\Z)', '', body)
+              print(body.strip())
           " | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
 
           # Download existing appcast from previous release to merge with (preserves history).

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -6,6 +6,7 @@
 import argparse
 import datetime
 import os
+import re
 import xml.etree.ElementTree as ET
 
 SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
@@ -28,6 +29,13 @@ hr { border: none; border-top: 1px solid #ddd; margin: 12px 0; }
   hr { border-color: #444; }
 }"""
 
+# Matches individual version-tagged divs inside cumulative descriptions.
+# Content never contains nested divs (only h3/h4/ul/li/p), so non-greedy works.
+_VERSION_DIV_RE = re.compile(
+    r'<div data-sparkle-version="([^"]+)">(.*?)</div>',
+    re.DOTALL,
+)
+
 
 def build_cumulative_description(
     current_version: str,
@@ -37,8 +45,10 @@ def build_cumulative_description(
     """Build an HTML description with all versions, tagged with data-sparkle-version."""
     version_attr = f"{{{SPARKLE_NS}}}shortVersionString"
     sections: list[str] = []
+    seen_versions: set[str] = set()
 
     if current_notes:
+        seen_versions.add(current_version)
         sections.append(
             f'<div data-sparkle-version="{current_version}">'
             f"<h3>v{current_version}</h3>\n{current_notes}\n</div>"
@@ -49,15 +59,30 @@ def build_cumulative_description(
         if enclosure is None:
             continue
         version = enclosure.get(version_attr, "")
-        if not version or version == current_version:
+        if not version or version in seen_versions:
             continue
         desc = item.find("description")
         if desc is None or not desc.text or not desc.text.strip():
             continue
-        sections.append(
-            f'<div data-sparkle-version="{version}">'
-            f"<h3>v{version}</h3>\n{desc.text.strip()}\n</div>"
-        )
+
+        text = desc.text.strip()
+        # Existing items may already have cumulative descriptions containing
+        # multiple version-tagged divs. Extract individual blocks to avoid
+        # nesting an entire cumulative blob inside a new div.
+        version_divs = list(_VERSION_DIV_RE.finditer(text))
+        if version_divs:
+            for m in version_divs:
+                div_version = m.group(1)
+                if div_version not in seen_versions:
+                    seen_versions.add(div_version)
+                    sections.append(m.group(0))
+        else:
+            # Legacy format: plain description without version tags.
+            seen_versions.add(version)
+            sections.append(
+                f'<div data-sparkle-version="{version}">'
+                f"<h3>v{version}</h3>\n{text}\n</div>"
+            )
 
     if not sections:
         return current_notes or ""

--- a/scripts/seed_appcast.py
+++ b/scripts/seed_appcast.py
@@ -51,15 +51,17 @@ def parse_changelog(text: str) -> list[dict[str, str]]:
 
 
 def clean_body(body: str) -> str:
-    """Strip commit hashes and PR links to keep release notes concise."""
+    """Strip noise from changelog entries to keep release notes user-facing."""
     # Remove trailing commit hash references like ([abc1234](https://...))
     body = re.sub(r"\s*\(\[[\da-f]+\]\([^)]+\)\)", "", body)
     # Remove issue/PR number links like ([#123](https://...))
     body = re.sub(r"\s*\(\[#\d+\]\([^)]+\)\)", "", body)
     # Remove standalone issue refs like , closes [#123](...)
     body = re.sub(r",?\s*closes\s+\[#\d+\]\([^)]+\)", "", body)
-    # Remove empty sections (header followed by blank lines)
-    body = re.sub(r"###\s+\w+\n+(?=###|\Z)", "", body)
+    # Remove CI and dependency update entries (not useful to end users)
+    body = re.sub(r"^\* \*\*(?:ci|deps):\*\*.*\n?", "", body, flags=re.MULTILINE)
+    # Remove empty sections (header followed by blank lines or end of string)
+    body = re.sub(r"### [^\n]+\n+(?=### |\Z)", "", body)
     return body.strip()
 
 

--- a/scripts/test_generate_appcast.py
+++ b/scripts/test_generate_appcast.py
@@ -239,6 +239,64 @@ def test_cumulative_description_includes_css_and_version_tags() -> None:
     print("PASS: cumulative_description_includes_css_and_version_tags")
 
 
+def test_cumulative_descriptions_are_not_nested() -> None:
+    """When existing items already have cumulative descriptions, versions must not duplicate."""
+    # Build a real appcast with cumulative descriptions by chaining two releases.
+    # This mirrors what happens in production: v1.0.0 is released, then v1.1.0
+    # merges with v1.0.0's appcast, producing cumulative descriptions.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        xml_v1 = build_appcast(
+            version="1.0.0",
+            signature="sig1",
+            dmg_length=1000,
+            dmg_url="https://example.com/app-1.0.0.dmg",
+            release_notes="<p>First release</p>",
+        )
+        f.write(xml_v1)
+        path_v1 = f.name
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        xml_v11 = build_appcast(
+            version="1.1.0",
+            signature="sig2",
+            dmg_length=2000,
+            dmg_url="https://example.com/app-1.1.0.dmg",
+            release_notes="<p>Second release</p>",
+            existing_path=path_v1,
+        )
+        f.write(xml_v11)
+        existing_path = f.name
+
+    os.unlink(path_v1)
+
+    try:
+        xml = build_appcast(
+            version="1.2.0",
+            signature="sig3",
+            dmg_length=3000,
+            dmg_url="https://example.com/app-1.2.0.dmg",
+            release_notes="<p>Third release</p>",
+            existing_path=existing_path,
+        )
+        root = parse(xml)
+        desc = root.find(".//item/description")
+        assert desc is not None
+
+        # Each version should appear exactly once in the cumulative description
+        text = desc.text
+        assert text.count('data-sparkle-version="1.2.0"') == 1, "v1.2.0 should appear once"
+        assert text.count('data-sparkle-version="1.1.0"') == 1, "v1.1.0 should appear once"
+        assert text.count('data-sparkle-version="1.0.0"') == 1, "v1.0.0 should appear once"
+
+        # Content from all three versions should be present
+        assert "Third release" in text
+        assert "Second release" in text
+        assert "First release" in text
+    finally:
+        os.unlink(existing_path)
+    print("PASS: cumulative_descriptions_are_not_nested")
+
+
 def test_handles_missing_existing_file() -> None:
     """When existing file doesn't exist, should produce single-item appcast."""
     xml = build_appcast(

--- a/scripts/test_seed_appcast.py
+++ b/scripts/test_seed_appcast.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# ABOUTME: Tests for seed_appcast.py.
+# ABOUTME: Covers changelog parsing, noise filtering, and markdown-to-HTML conversion.
+"""Tests for seed_appcast.py."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from seed_appcast import clean_body, parse_changelog, markdown_to_html
+
+
+def test_clean_body_removes_ci_entries() -> None:
+    body = """\
+### Bug Fixes
+
+* **ci:** download appcast from previous release, not latest
+* DMG skyline clipped by Finder status bar"""
+    result = clean_body(body)
+    assert "ci:" not in result
+    assert "DMG skyline clipped" in result
+    print("PASS: clean_body_removes_ci_entries")
+
+
+def test_clean_body_removes_deps_entries() -> None:
+    body = """\
+### Bug Fixes
+
+* **deps:** update dependency foo to v2.0
+* **deps:** update dependency bar to v3.0
+* actual bug fix here"""
+    result = clean_body(body)
+    assert "deps:" not in result
+    assert "actual bug fix here" in result
+    print("PASS: clean_body_removes_deps_entries")
+
+
+def test_clean_body_removes_empty_sections() -> None:
+    body = """\
+### Bug Fixes
+
+* **ci:** only a ci entry
+
+### Features
+
+* real feature here"""
+    result = clean_body(body)
+    assert "Bug Fixes" not in result
+    assert "Features" in result
+    assert "real feature here" in result
+    print("PASS: clean_body_removes_empty_sections")
+
+
+def test_clean_body_returns_empty_when_all_filtered() -> None:
+    body = """\
+### Bug Fixes
+
+* **ci:** increase Node heap size for Monaco editor build"""
+    result = clean_body(body)
+    assert result == ""
+    print("PASS: clean_body_returns_empty_when_all_filtered")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, func in list(globals().items()):
+        if name.startswith("test_") and callable(func):
+            try:
+                func()
+            except (AssertionError, TypeError) as e:
+                print(f"FAIL: {name}: {e}")
+                failures += 1
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary
- Fix cumulative description builder nesting entire cumulative blobs inside new version divs, causing older versions to appear multiple times in the update popover
- Filter out `ci:` and `deps:` scoped changelog entries (and empty sections after filtering) from both the release workflow and the seed script, since they are not user-facing
- Add test for the deduplication fix and tests for seed_appcast noise filtering

## Test plan
- [x] All existing `test_generate_appcast.py` tests pass
- [x] New `test_cumulative_descriptions_are_not_nested` test verifies versions appear exactly once
- [x] New `test_seed_appcast.py` tests verify ci/deps filtering and empty section removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)