### PR TITLE
refactor: rebuild Sparkle changelog from CHANGELOG.md on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,24 +260,9 @@ jobs:
             exit 1
           fi
 
-          # Extract current version's changelog section, filter noise, and convert to HTML
-          RELEASE_NOTES=$(python3 -c "
-          import re, sys
-          text = open('CHANGELOG.md').read()
-          # Match from '## [version]' to the next '## [' or end of file
-          pattern = r'## \[${VERSION}\].*?\n(.*?)(?=\n## \[|\Z)'
-          m = re.search(pattern, text, re.DOTALL)
-          if m:
-              body = m.group(1).strip()
-              # Remove CI and dependency entries (not useful to end users)
-              body = re.sub(r'^\* \*\*(?:ci|deps):\*\*.*\n?', '', body, flags=re.MULTILINE)
-              # Remove sections left empty after filtering
-              body = re.sub(r'### [^\n]+\n+(?=### |\Z)', '', body)
-              print(body.strip())
-          " | uvx --with markdown python3 -c "import sys, markdown; print(markdown.markdown(sys.stdin.read()))")
-
-          # Download existing appcast from previous release to merge with (preserves history).
-          # Cannot use --latest because release-please already created the current (empty) release.
+          # Download existing appcast from previous release to merge with (preserves items
+          # for the Homebrew update popover). Cannot use --latest because release-please
+          # already created the current (empty) release.
           PREV_TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 10 --json tagName --jq "[.[] | select(.tagName != \"$TAG_NAME\")][0].tagName")
           if [ -n "$PREV_TAG" ]; then
             gh release download "$PREV_TAG" --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output existing-appcast.xml || true
@@ -289,7 +274,7 @@ jobs:
             --signature "$SIGNATURE" \
             --dmg-path "build/release/$DMG_NAME" \
             --dmg-url "$DMG_URL" \
-            --release-notes "$RELEASE_NOTES" \
+            --changelog CHANGELOG.md \
             --existing existing-appcast.xml \
             --output appcast.xml
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,53 @@
+# ABOUTME: Parses CHANGELOG.md and converts entries to filtered HTML.
+# ABOUTME: Shared by generate_appcast.py and seed_appcast.py.
+"""Parse CHANGELOG.md and convert entries to filtered, user-facing HTML."""
+
+import re
+
+_VERSION_RE = re.compile(
+    r"^## \[?(\d+\.\d+\.\d+)\]?(?:\([^)]*\))?\s*\((\d{4}-\d{2}-\d{2})\)",
+)
+
+
+def parse(text: str) -> list[dict[str, str]]:
+    """Parse CHANGELOG.md into [{version, date, body}, ...]."""
+    releases: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    lines: list[str] = []
+
+    for line in text.splitlines():
+        m = _VERSION_RE.match(line)
+        if m:
+            if current:
+                current["body"] = "\n".join(lines).strip()
+                releases.append(current)
+            current = {"version": m.group(1), "date": m.group(2)}
+            lines = []
+        elif current:
+            lines.append(line)
+
+    if current:
+        current["body"] = "\n".join(lines).strip()
+        releases.append(current)
+
+    return releases
+
+
+def clean_body(body: str) -> str:
+    """Strip noise to keep only user-facing content."""
+    body = re.sub(r"\s*\(\[[\da-f]+\]\([^)]+\)\)", "", body)  # commit hash links
+    body = re.sub(r"\s*\(\[#\d+\]\([^)]+\)\)", "", body)  # PR number links
+    body = re.sub(r",?\s*closes\s+\[#\d+\]\([^)]+\)", "", body)  # closes refs
+    body = re.sub(r"^\* \*\*(?:ci|deps):\*\*.*\n?", "", body, flags=re.MULTILINE)
+    body = re.sub(r"### [^\n]+\n+(?=### |\Z)", "", body)  # empty sections
+    return body.strip()
+
+
+def to_html(md: str) -> str:
+    """Convert changelog markdown subset to HTML using regex substitutions."""
+    html = re.sub(r"^### (.+)$", r"<h4>\1</h4>", md, flags=re.MULTILINE)
+    html = re.sub(r"^\* (.+)$", r"<li>\1</li>", html, flags=re.MULTILINE)
+    html = re.sub(r"\*\*([^*]+)\*\*", r"<b>\1</b>", html)
+    html = re.sub(r"((?:<li>[^\n]*</li>\n?)+)", r"<ul>\n\1</ul>", html)
+    html = re.sub(r"\n{2,}", "\n", html)
+    return html.strip()

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python3
 # ABOUTME: Generates a Sparkle appcast.xml from release metadata and DMG signature.
-# ABOUTME: Merges with existing appcast to accumulate changelog history across releases.
+# ABOUTME: Builds cumulative release notes fresh from CHANGELOG.md on every release.
 """Generate a Sparkle appcast.xml from release metadata and DMG signature."""
 
 import argparse
 import datetime
 import os
-import re
 import xml.etree.ElementTree as ET
+
+import changelog
 
 SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
 ET.register_namespace("sparkle", SPARKLE_NS)
 
-# CSS injected into the cumulative release notes HTML. Sparkle (2.5+) adds the
-# class "sparkle-installed-version" to the div whose data-sparkle-version matches
-# the user's installed build. The general sibling combinator (~) hides everything
-# older than the installed version.
-RELEASE_NOTES_CSS = """\
+CSS = """\
 body { font-family: -apple-system, sans-serif; font-size: 13px; line-height: 1.5; padding: 8px 12px; }
 h3 { margin: 12px 0 4px; font-size: 15px; }
 h4 { margin: 8px 0 4px; font-size: 13px; }
@@ -29,113 +26,30 @@ hr { border: none; border-top: 1px solid #ddd; margin: 12px 0; }
   hr { border-color: #444; }
 }"""
 
-# Matches individual version-tagged divs inside cumulative descriptions.
-# Content never contains nested divs (only h3/h4/ul/li/p), so non-greedy works.
-_VERSION_DIV_RE = re.compile(
-    r'<div data-sparkle-version="([^"]+)">(.*?)</div>',
-    re.DOTALL,
-)
 
-
-def build_cumulative_description(
-    current_version: str,
-    current_notes: str | None,
-    existing_items: list[ET.Element],
-) -> str:
-    """Build an HTML description with all versions, tagged with data-sparkle-version."""
-    version_attr = f"{{{SPARKLE_NS}}}shortVersionString"
+def build_description(version: str, changelog_text: str) -> str:
+    """Build cumulative HTML from CHANGELOG.md, starting at the given version."""
     sections: list[str] = []
-    seen_versions: set[str] = set()
+    found = False
 
-    if current_notes:
-        seen_versions.add(current_version)
+    for entry in changelog.parse(changelog_text):
+        if not found:
+            if entry["version"] == version:
+                found = True
+            else:
+                continue
+        body = changelog.clean_body(entry["body"])
+        if not body:
+            continue
+        html = changelog.to_html(body)
+        v = entry["version"]
         sections.append(
-            f'<div data-sparkle-version="{current_version}">'
-            f"<h3>v{current_version}</h3>\n{current_notes}\n</div>"
+            f'<div data-sparkle-version="{v}"><h3>v{v}</h3>\n{html}\n</div>'
         )
 
-    for item in existing_items:
-        enclosure = item.find("enclosure")
-        if enclosure is None:
-            continue
-        version = enclosure.get(version_attr, "")
-        if not version or version in seen_versions:
-            continue
-        desc = item.find("description")
-        if desc is None or not desc.text or not desc.text.strip():
-            continue
-
-        text = desc.text.strip()
-        # Existing items may already have cumulative descriptions containing
-        # multiple version-tagged divs. Extract individual blocks to avoid
-        # nesting an entire cumulative blob inside a new div.
-        version_divs = list(_VERSION_DIV_RE.finditer(text))
-        if version_divs:
-            for m in version_divs:
-                div_version = m.group(1)
-                if div_version not in seen_versions:
-                    seen_versions.add(div_version)
-                    sections.append(m.group(0))
-        else:
-            # Legacy format: plain description without version tags.
-            seen_versions.add(version)
-            sections.append(
-                f'<div data-sparkle-version="{version}">'
-                f"<h3>v{version}</h3>\n{text}\n</div>"
-            )
-
     if not sections:
-        return current_notes or ""
-
-    separator = "\n<hr>\n"
-    body = separator.join(sections)
-    return f"<style>{RELEASE_NOTES_CSS}</style>\n{body}"
-
-
-def build_item(
-    version: str,
-    signature: str,
-    dmg_length: int,
-    dmg_url: str,
-    description: str,
-    min_os: str = "14.0",
-) -> ET.Element:
-    """Build a single appcast <item> element."""
-    item = ET.Element("item")
-    ET.SubElement(item, "title").text = f"Version {version}"
-    ET.SubElement(
-        item, "link"
-    ).text = f"https://github.com/alltuner/factoryfloor/releases/tag/v{version}"
-    pub_date = datetime.datetime.now(datetime.timezone.utc).strftime(
-        "%a, %d %b %Y %H:%M:%S %z"
-    )
-    ET.SubElement(item, "pubDate").text = pub_date
-    ns = f"{{{SPARKLE_NS}}}"
-    ET.SubElement(item, f"{ns}minimumSystemVersion").text = min_os
-
-    if description:
-        ET.SubElement(item, "description").text = description
-
-    enclosure = ET.SubElement(item, "enclosure")
-    enclosure.set("url", dmg_url)
-    enclosure.set(f"{ns}version", version)
-    enclosure.set(f"{ns}shortVersionString", version)
-    enclosure.set(f"{ns}edSignature", signature)
-    enclosure.set("length", str(dmg_length))
-    enclosure.set("type", "application/octet-stream")
-
-    return item
-
-
-def parse_existing_items(existing_path: str) -> list[ET.Element]:
-    """Parse existing appcast XML and return its <item> elements."""
-    if not os.path.exists(existing_path):
-        return []
-    try:
-        tree = ET.parse(existing_path)
-        return list(tree.findall(".//item"))
-    except ET.ParseError:
-        return []
+        return ""
+    return f"<style>{CSS}</style>\n" + "\n<hr>\n".join(sections)
 
 
 def build_appcast(
@@ -144,15 +58,19 @@ def build_appcast(
     dmg_length: int,
     dmg_url: str,
     min_os: str = "14.0",
-    release_notes: str | None = None,
+    changelog_text: str | None = None,
     existing_path: str | None = None,
 ) -> str:
-    existing_items = parse_existing_items(existing_path) if existing_path else []
+    # Parse existing items for carry-forward
+    existing_items: list[ET.Element] = []
+    if existing_path and os.path.exists(existing_path):
+        try:
+            existing_items = list(ET.parse(existing_path).findall(".//item"))
+        except ET.ParseError:
+            pass
 
-    cumulative_desc = build_cumulative_description(
-        version, release_notes, existing_items
-    )
-
+    # Build RSS feed
+    ns = f"{{{SPARKLE_NS}}}"
     rss = ET.Element("rss")
     rss.set("version", "2.0")
     rss.set("xmlns:dc", "http://purl.org/dc/elements/1.1/")
@@ -163,57 +81,69 @@ def build_appcast(
     ET.SubElement(channel, "description").text = "Factory Floor updates"
     ET.SubElement(channel, "language").text = "en"
 
-    new_item = build_item(
-        version=version,
-        signature=signature,
-        dmg_length=dmg_length,
-        dmg_url=dmg_url,
-        description=cumulative_desc,
-        min_os=min_os,
-    )
-    channel.append(new_item)
+    # New release item
+    item = ET.SubElement(channel, "item")
+    ET.SubElement(item, "title").text = f"Version {version}"
+    ET.SubElement(
+        item, "link"
+    ).text = f"https://github.com/alltuner/factoryfloor/releases/tag/v{version}"
+    ET.SubElement(item, "pubDate").text = datetime.datetime.now(
+        datetime.timezone.utc
+    ).strftime("%a, %d %b %Y %H:%M:%S %z")
+    ET.SubElement(item, f"{ns}minimumSystemVersion").text = min_os
 
-    # Append previous items (used by the in-app Homebrew update popover)
-    version_attr = f"{{{SPARKLE_NS}}}shortVersionString"
-    for old_item in existing_items:
-        enclosure = old_item.find("enclosure")
-        if enclosure is not None:
-            old_version = enclosure.get(version_attr, "")
-            if old_version == version:
-                continue
-        channel.append(old_item)
+    if changelog_text:
+        desc = build_description(version, changelog_text)
+        if desc:
+            ET.SubElement(item, "description").text = desc
+
+    enclosure = ET.SubElement(item, "enclosure")
+    enclosure.set("url", dmg_url)
+    enclosure.set(f"{ns}version", version)
+    enclosure.set(f"{ns}shortVersionString", version)
+    enclosure.set(f"{ns}edSignature", signature)
+    enclosure.set("length", str(dmg_length))
+    enclosure.set("type", "application/octet-stream")
+
+    # Carry forward previous items (used by the in-app Homebrew update popover)
+    ver_attr = f"{ns}shortVersionString"
+    for old in existing_items:
+        enc = old.find("enclosure")
+        if enc is not None and enc.get(ver_attr) == version:
+            continue
+        channel.append(old)
 
     ET.indent(rss, space="  ")
-    xml_str = ET.tostring(rss, encoding="unicode", xml_declaration=True)
-    return xml_str
+    return ET.tostring(rss, encoding="unicode", xml_declaration=True)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate Sparkle appcast.xml")
-    parser.add_argument("--version", required=True, help="Release version (semver)")
-    parser.add_argument("--signature", required=True, help="Ed25519 signature from sign_update")
-    parser.add_argument("--dmg-path", required=True, help="Path to the DMG file")
-    parser.add_argument("--dmg-url", required=True, help="Download URL for the DMG")
-    parser.add_argument("--release-notes", default=None, help="Release notes HTML to embed")
-    parser.add_argument("--existing", default=None, help="Path to existing appcast.xml to merge with")
-    parser.add_argument("--output", default="appcast.xml", help="Output path")
-    args = parser.parse_args()
+    p = argparse.ArgumentParser(description="Generate Sparkle appcast.xml")
+    p.add_argument("--version", required=True)
+    p.add_argument("--signature", required=True)
+    p.add_argument("--dmg-path", required=True)
+    p.add_argument("--dmg-url", required=True)
+    p.add_argument("--changelog", default=None, help="Path to CHANGELOG.md")
+    p.add_argument("--existing", default=None, help="Existing appcast.xml to merge items from")
+    p.add_argument("--output", default="appcast.xml")
+    args = p.parse_args()
 
-    dmg_length = os.path.getsize(args.dmg_path)
+    changelog_text = None
+    if args.changelog:
+        with open(args.changelog) as f:
+            changelog_text = f.read()
+
     xml = build_appcast(
         version=args.version,
         signature=args.signature,
-        dmg_length=dmg_length,
+        dmg_length=os.path.getsize(args.dmg_path),
         dmg_url=args.dmg_url,
-        release_notes=args.release_notes,
+        changelog_text=changelog_text,
         existing_path=args.existing,
     )
-
     with open(args.output, "w") as f:
-        f.write(xml)
-        f.write("\n")
-
-    print(f"Generated {args.output} for v{args.version} ({dmg_length} bytes)")
+        f.write(xml + "\n")
+    print(f"Generated {args.output} for v{args.version}")
 
 
 if __name__ == "__main__":

--- a/scripts/seed_appcast.py
+++ b/scripts/seed_appcast.py
@@ -1,110 +1,29 @@
 #!/usr/bin/env python3
 # ABOUTME: Seeds an appcast.xml with historical releases from CHANGELOG.md.
-# ABOUTME: One-time script to populate changelog history before the first accumulating release.
-"""Seed an appcast.xml with historical releases from CHANGELOG.md.
+# ABOUTME: One-time script; generate_appcast.py handles ongoing releases.
+"""Seed an appcast.xml with historical releases from CHANGELOG.md."""
 
-Generates items for all versions found in CHANGELOG.md. These items have
-release notes and links but no enclosure/DMG data (since those releases
-already shipped). The generate_appcast.py script will prepend real items
-with enclosure data on each new release.
-"""
-
-import re
-import sys
+import argparse
 import xml.etree.ElementTree as ET
+
+import changelog
 
 SPARKLE_NS = "https://www.andymatuschak.org/xml-namespaces/sparkle"
 ET.register_namespace("sparkle", SPARKLE_NS)
 
 REPO_URL = "https://github.com/alltuner/factoryfloor"
 
-# Matches "## [0.1.70](...) (2026-04-13)" or "## 0.1.70 (2026-04-13)"
-VERSION_PATTERN = re.compile(
-    r"^## \[?(\d+\.\d+\.\d+)\]?"
-    r"(?:\([^)]*\))?"
-    r"\s*\((\d{4}-\d{2}-\d{2})\)",
-)
 
+def main() -> None:
+    p = argparse.ArgumentParser(description="Seed appcast from CHANGELOG.md")
+    p.add_argument("--changelog", default="CHANGELOG.md")
+    p.add_argument("--output", default="appcast-seed.xml")
+    args = p.parse_args()
 
-def parse_changelog(text: str) -> list[dict[str, str]]:
-    """Parse CHANGELOG.md into a list of {version, date, body} dicts."""
-    releases: list[dict[str, str]] = []
-    current: dict[str, str] | None = None
-    body_lines: list[str] = []
+    with open(args.changelog) as f:
+        releases = changelog.parse(f.read())
 
-    for line in text.splitlines():
-        match = VERSION_PATTERN.match(line)
-        if match:
-            if current is not None:
-                current["body"] = "\n".join(body_lines).strip()
-                releases.append(current)
-            current = {"version": match.group(1), "date": match.group(2)}
-            body_lines = []
-        elif current is not None:
-            body_lines.append(line)
-
-    if current is not None:
-        current["body"] = "\n".join(body_lines).strip()
-        releases.append(current)
-
-    return releases
-
-
-def clean_body(body: str) -> str:
-    """Strip noise from changelog entries to keep release notes user-facing."""
-    # Remove trailing commit hash references like ([abc1234](https://...))
-    body = re.sub(r"\s*\(\[[\da-f]+\]\([^)]+\)\)", "", body)
-    # Remove issue/PR number links like ([#123](https://...))
-    body = re.sub(r"\s*\(\[#\d+\]\([^)]+\)\)", "", body)
-    # Remove standalone issue refs like , closes [#123](...)
-    body = re.sub(r",?\s*closes\s+\[#\d+\]\([^)]+\)", "", body)
-    # Remove CI and dependency update entries (not useful to end users)
-    body = re.sub(r"^\* \*\*(?:ci|deps):\*\*.*\n?", "", body, flags=re.MULTILINE)
-    # Remove empty sections (header followed by blank lines or end of string)
-    body = re.sub(r"### [^\n]+\n+(?=### |\Z)", "", body)
-    return body.strip()
-
-
-def markdown_to_html(md: str) -> str:
-    """Minimal markdown to HTML for changelog content."""
-    lines = md.splitlines()
-    html_parts: list[str] = []
-    in_list = False
-
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            if in_list:
-                html_parts.append("</ul>")
-                in_list = False
-            continue
-        if stripped.startswith("### "):
-            if in_list:
-                html_parts.append("</ul>")
-                in_list = False
-            heading = stripped[4:]
-            html_parts.append(f"<h4>{heading}</h4>")
-        elif stripped.startswith("* "):
-            if not in_list:
-                html_parts.append("<ul>")
-                in_list = True
-            content = stripped[2:]
-            # Bold scope prefix like **ci:**
-            content = re.sub(r"\*\*([^*]+)\*\*", r"<b>\1</b>", content)
-            html_parts.append(f"<li>{content}</li>")
-        else:
-            html_parts.append(f"<p>{stripped}</p>")
-
-    if in_list:
-        html_parts.append("</ul>")
-
-    return "\n".join(html_parts)
-
-
-def build_seed_appcast(changelog_text: str) -> str:
-    """Build an appcast XML with historical releases from CHANGELOG.md."""
-    releases = parse_changelog(changelog_text)
-
+    ns = f"{{{SPARKLE_NS}}}"
     rss = ET.Element("rss")
     rss.set("version", "2.0")
     rss.set("xmlns:dc", "http://purl.org/dc/elements/1.1/")
@@ -115,49 +34,23 @@ def build_seed_appcast(changelog_text: str) -> str:
     ET.SubElement(channel, "description").text = "Factory Floor updates"
     ET.SubElement(channel, "language").text = "en"
 
-    ns = f"{{{SPARKLE_NS}}}"
-
     for release in releases:
-        version = release["version"]
-        body = clean_body(release["body"])
+        body = changelog.clean_body(release["body"])
         if not body:
             continue
-
-        html = markdown_to_html(body)
-
+        v = release["version"]
         item = ET.SubElement(channel, "item")
-        ET.SubElement(item, "title").text = f"Version {version}"
-        ET.SubElement(item, "link").text = f"{REPO_URL}/releases/tag/v{version}"
-        ET.SubElement(item, "description").text = html
-
-        # Enclosure with version info but no DMG data (historical releases)
-        enclosure = ET.SubElement(item, "enclosure")
-        enclosure.set(f"{ns}version", version)
-        enclosure.set(f"{ns}shortVersionString", version)
+        ET.SubElement(item, "title").text = f"Version {v}"
+        ET.SubElement(item, "link").text = f"{REPO_URL}/releases/tag/v{v}"
+        ET.SubElement(item, "description").text = changelog.to_html(body)
+        enc = ET.SubElement(item, "enclosure")
+        enc.set(f"{ns}version", v)
+        enc.set(f"{ns}shortVersionString", v)
 
     ET.indent(rss, space="  ")
-    return ET.tostring(rss, encoding="unicode", xml_declaration=True)
-
-
-def main() -> None:
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Seed appcast from CHANGELOG.md")
-    parser.add_argument(
-        "--changelog", default="CHANGELOG.md", help="Path to CHANGELOG.md"
-    )
-    parser.add_argument("--output", default="appcast-seed.xml", help="Output path")
-    args = parser.parse_args()
-
-    with open(args.changelog) as f:
-        text = f.read()
-
-    xml = build_seed_appcast(text)
+    xml = ET.tostring(rss, encoding="unicode", xml_declaration=True)
     with open(args.output, "w") as f:
-        f.write(xml)
-        f.write("\n")
-
-    releases = parse_changelog(text)
+        f.write(xml + "\n")
     print(f"Seeded {args.output} with {len(releases)} releases")
 
 

--- a/scripts/test_generate_appcast.py
+++ b/scripts/test_generate_appcast.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ABOUTME: Tests for generate_appcast.py.
-# ABOUTME: Covers release notes, HTML entities, existing appcast merging, and deduplication.
+# ABOUTME: Covers cumulative descriptions from CHANGELOG.md, existing appcast merging, and noise filtering.
 """Tests for generate_appcast.py."""
 
 import tempfile
@@ -13,13 +13,48 @@ from generate_appcast import build_appcast, SPARKLE_NS
 
 NS = f"{{{SPARKLE_NS}}}"
 
+SAMPLE_CHANGELOG = """\
+# Changelog
+
+## [1.2.0](https://example.com) (2026-04-13)
+
+### Features
+
+* add cool new feature
+
+### Bug Fixes
+
+* **ci:** fix build step
+* **deps:** update dependency foo to v2
+* fix actual user-facing bug
+
+## [1.1.0](https://example.com) (2026-04-12)
+
+### Features
+
+* show cumulative changelog in update popover ([#18](https://example.com)) ([abc1234](https://example.com))
+
+## [1.0.0](https://example.com) (2026-04-11)
+
+### Bug Fixes
+
+* **ci:** increase heap size
+* **deps:** update dependency bar to v3
+
+## [0.9.0](https://example.com) (2026-04-10)
+
+### Features
+
+* initial release
+"""
+
 
 def parse(xml_str: str) -> ET.Element:
     return ET.fromstring(xml_str)
 
 
-def test_no_release_notes_omits_description() -> None:
-    """When no release notes are provided, description element should be absent."""
+def test_no_changelog_omits_description() -> None:
+    """When no changelog is provided, description element should be absent."""
     xml = build_appcast(
         version="1.0.0",
         signature="abc123",
@@ -28,47 +63,114 @@ def test_no_release_notes_omits_description() -> None:
     )
     root = parse(xml)
     item = root.find(".//item")
-    assert item is not None, "Expected <item> element"
+    assert item is not None
     desc = item.find("description")
-    assert desc is None, "Expected no <description> when release_notes not provided"
-    print("PASS: no_release_notes_omits_description")
+    assert desc is None, "Expected no <description> when changelog not provided"
+    print("PASS: no_changelog_omits_description")
 
 
-def test_release_notes_embedded_as_description() -> None:
-    """When release notes are provided, they should appear in a description element."""
-    notes = "## What's New\n\n* Added feature X\n* Fixed bug Y"
+def test_description_built_from_changelog() -> None:
+    """Description should contain version-tagged sections from CHANGELOG.md."""
     xml = build_appcast(
         version="1.2.0",
-        signature="sig456",
-        dmg_length=5000,
+        signature="sig",
+        dmg_length=1000,
         dmg_url="https://example.com/app.dmg",
-        release_notes=notes,
+        changelog_text=SAMPLE_CHANGELOG,
     )
-    root = parse(xml)
-    item = root.find(".//item")
-    assert item is not None, "Expected <item> element"
-    desc = item.find("description")
-    assert desc is not None, "Expected <description> element when release_notes provided"
-    assert notes in desc.text, f"Expected release notes in description, got: {desc.text}"
-    print("PASS: release_notes_embedded_as_description")
-
-
-def test_release_notes_with_html_entities() -> None:
-    """Release notes with special XML characters should be handled safely."""
-    notes = "Fix for <div> & \"quotes\" in output"
-    xml = build_appcast(
-        version="1.3.0",
-        signature="sig789",
-        dmg_length=3000,
-        dmg_url="https://example.com/app.dmg",
-        release_notes=notes,
-    )
-    # Should parse without error (XML-safe)
     root = parse(xml)
     desc = root.find(".//item/description")
     assert desc is not None
-    assert notes in desc.text
-    print("PASS: release_notes_with_html_entities")
+    text = desc.text
+
+    # Current and older versions should be present
+    assert 'data-sparkle-version="1.2.0"' in text
+    assert 'data-sparkle-version="1.1.0"' in text
+    assert 'data-sparkle-version="0.9.0"' in text
+
+    # User-facing content should be present
+    assert "add cool new feature" in text
+    assert "fix actual user-facing bug" in text
+    assert "cumulative changelog" in text
+    assert "initial release" in text
+
+    # CSS for Sparkle version hiding should be present
+    assert "sparkle-installed-version" in text
+    print("PASS: description_built_from_changelog")
+
+
+def test_ci_and_deps_entries_are_filtered() -> None:
+    """CI and dependency entries should not appear in the description."""
+    xml = build_appcast(
+        version="1.2.0",
+        signature="sig",
+        dmg_length=1000,
+        dmg_url="https://example.com/app.dmg",
+        changelog_text=SAMPLE_CHANGELOG,
+    )
+    root = parse(xml)
+    desc = root.find(".//item/description")
+    assert desc is not None
+    text = desc.text
+    assert "ci:" not in text, "CI entries should be filtered"
+    assert "deps:" not in text, "Deps entries should be filtered"
+    print("PASS: ci_and_deps_entries_are_filtered")
+
+
+def test_version_with_only_noise_is_skipped() -> None:
+    """A version whose entries are all ci/deps should not appear in the changelog."""
+    xml = build_appcast(
+        version="1.2.0",
+        signature="sig",
+        dmg_length=1000,
+        dmg_url="https://example.com/app.dmg",
+        changelog_text=SAMPLE_CHANGELOG,
+    )
+    root = parse(xml)
+    desc = root.find(".//item/description")
+    assert desc is not None
+    text = desc.text
+    # v1.0.0 only has ci/deps entries, so it should be absent
+    assert 'data-sparkle-version="1.0.0"' not in text, "Version with only noise should be skipped"
+    print("PASS: version_with_only_noise_is_skipped")
+
+
+def test_each_version_appears_exactly_once() -> None:
+    """No version should be duplicated in the cumulative description."""
+    xml = build_appcast(
+        version="1.2.0",
+        signature="sig",
+        dmg_length=1000,
+        dmg_url="https://example.com/app.dmg",
+        changelog_text=SAMPLE_CHANGELOG,
+    )
+    root = parse(xml)
+    desc = root.find(".//item/description")
+    assert desc is not None
+    text = desc.text
+    assert text.count('data-sparkle-version="1.2.0"') == 1
+    assert text.count('data-sparkle-version="1.1.0"') == 1
+    assert text.count('data-sparkle-version="0.9.0"') == 1
+    print("PASS: each_version_appears_exactly_once")
+
+
+def test_commit_hashes_and_pr_links_are_stripped() -> None:
+    """Commit hashes and PR links from release-please should be cleaned up."""
+    xml = build_appcast(
+        version="1.1.0",
+        signature="sig",
+        dmg_length=1000,
+        dmg_url="https://example.com/app.dmg",
+        changelog_text=SAMPLE_CHANGELOG,
+    )
+    root = parse(xml)
+    desc = root.find(".//item/description")
+    assert desc is not None
+    text = desc.text
+    assert "abc1234" not in text, "Commit hashes should be stripped"
+    assert "#18" not in text, "PR number links should be stripped"
+    assert "cumulative changelog" in text, "Content should remain"
+    print("PASS: commit_hashes_and_pr_links_are_stripped")
 
 
 def test_item_contains_release_link() -> None:
@@ -81,9 +183,9 @@ def test_item_contains_release_link() -> None:
     )
     root = parse(xml)
     item = root.find(".//item")
-    assert item is not None, "Expected <item> element"
+    assert item is not None
     link = item.find("link")
-    assert link is not None, "Expected <link> element in item"
+    assert link is not None
     assert link.text == "https://github.com/alltuner/factoryfloor/releases/tag/v1.4.0"
     print("PASS: item_contains_release_link")
 
@@ -111,34 +213,40 @@ def test_merges_with_existing_appcast() -> None:
         f.write(existing)
         existing_path = f.name
 
+    changelog_text = """\
+## [1.1.0](https://example.com) (2026-04-12)
+
+### Features
+
+* new feature
+
+## [1.0.0](https://example.com) (2026-04-11)
+
+### Features
+
+* first release
+"""
+
     try:
         xml = build_appcast(
             version="1.1.0",
             signature="newsig",
             dmg_length=2000,
             dmg_url="https://example.com/app-1.1.0.dmg",
-            release_notes="Bug fixes",
+            changelog_text=changelog_text,
             existing_path=existing_path,
         )
         root = parse(xml)
         items = root.findall(".//item")
         assert len(items) == 2, f"Expected 2 items, got {len(items)}"
 
-        # First item has cumulative description with both versions
+        # First item is the new version
         enc0 = items[0].find("enclosure")
         assert enc0.get(f"{NS}shortVersionString") == "1.1.0"
-        desc0 = items[0].find("description")
-        assert desc0 is not None
-        assert "Bug fixes" in desc0.text
-        assert "First release" in desc0.text
-        assert 'data-sparkle-version="1.1.0"' in desc0.text
-        assert 'data-sparkle-version="1.0.0"' in desc0.text
 
-        # Second item (old) keeps its own description
+        # Second item (old) is preserved
         enc1 = items[1].find("enclosure")
         assert enc1.get(f"{NS}shortVersionString") == "1.0.0"
-        desc1 = items[1].find("description")
-        assert desc1 is not None and desc1.text == "First release"
     finally:
         os.unlink(existing_path)
     print("PASS: merges_with_existing_appcast")
@@ -183,120 +291,6 @@ def test_deduplicates_same_version() -> None:
     print("PASS: deduplicates_same_version")
 
 
-def test_cumulative_description_includes_css_and_version_tags() -> None:
-    """Cumulative description should have CSS for Sparkle version highlighting."""
-    existing = """\
-<?xml version='1.0' encoding='utf-8'?>
-<rss version="2.0" xmlns:sparkle="https://www.andymatuschak.org/xml-namespaces/sparkle">
-  <channel>
-    <item>
-      <title>Version 1.1.0</title>
-      <description>&lt;p&gt;Middle release&lt;/p&gt;</description>
-      <enclosure sparkle:version="1.1.0" sparkle:shortVersionString="1.1.0"
-                 sparkle:edSignature="sig2" length="1500" url="https://example.com/1.1.dmg"
-                 type="application/octet-stream" />
-    </item>
-    <item>
-      <title>Version 1.0.0</title>
-      <description>Initial release</description>
-      <enclosure sparkle:version="1.0.0" sparkle:shortVersionString="1.0.0"
-                 sparkle:edSignature="sig1" length="1000" url="https://example.com/1.0.dmg"
-                 type="application/octet-stream" />
-    </item>
-  </channel>
-</rss>"""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        f.write(existing)
-        existing_path = f.name
-
-    try:
-        xml = build_appcast(
-            version="1.2.0",
-            signature="sig3",
-            dmg_length=2000,
-            dmg_url="https://example.com/1.2.dmg",
-            release_notes="<p>Latest stuff</p>",
-            existing_path=existing_path,
-        )
-        root = parse(xml)
-        desc = root.find(".//item/description")
-        assert desc is not None
-
-        # Should contain CSS with sparkle-installed-version rule
-        assert "sparkle-installed-version" in desc.text
-
-        # Should contain all three versions tagged
-        assert 'data-sparkle-version="1.2.0"' in desc.text
-        assert 'data-sparkle-version="1.1.0"' in desc.text
-        assert 'data-sparkle-version="1.0.0"' in desc.text
-
-        # Content from all versions present
-        assert "Latest stuff" in desc.text
-        assert "Middle release" in desc.text
-        assert "Initial release" in desc.text
-    finally:
-        os.unlink(existing_path)
-    print("PASS: cumulative_description_includes_css_and_version_tags")
-
-
-def test_cumulative_descriptions_are_not_nested() -> None:
-    """When existing items already have cumulative descriptions, versions must not duplicate."""
-    # Build a real appcast with cumulative descriptions by chaining two releases.
-    # This mirrors what happens in production: v1.0.0 is released, then v1.1.0
-    # merges with v1.0.0's appcast, producing cumulative descriptions.
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        xml_v1 = build_appcast(
-            version="1.0.0",
-            signature="sig1",
-            dmg_length=1000,
-            dmg_url="https://example.com/app-1.0.0.dmg",
-            release_notes="<p>First release</p>",
-        )
-        f.write(xml_v1)
-        path_v1 = f.name
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        xml_v11 = build_appcast(
-            version="1.1.0",
-            signature="sig2",
-            dmg_length=2000,
-            dmg_url="https://example.com/app-1.1.0.dmg",
-            release_notes="<p>Second release</p>",
-            existing_path=path_v1,
-        )
-        f.write(xml_v11)
-        existing_path = f.name
-
-    os.unlink(path_v1)
-
-    try:
-        xml = build_appcast(
-            version="1.2.0",
-            signature="sig3",
-            dmg_length=3000,
-            dmg_url="https://example.com/app-1.2.0.dmg",
-            release_notes="<p>Third release</p>",
-            existing_path=existing_path,
-        )
-        root = parse(xml)
-        desc = root.find(".//item/description")
-        assert desc is not None
-
-        # Each version should appear exactly once in the cumulative description
-        text = desc.text
-        assert text.count('data-sparkle-version="1.2.0"') == 1, "v1.2.0 should appear once"
-        assert text.count('data-sparkle-version="1.1.0"') == 1, "v1.1.0 should appear once"
-        assert text.count('data-sparkle-version="1.0.0"') == 1, "v1.0.0 should appear once"
-
-        # Content from all three versions should be present
-        assert "Third release" in text
-        assert "Second release" in text
-        assert "First release" in text
-    finally:
-        os.unlink(existing_path)
-    print("PASS: cumulative_descriptions_are_not_nested")
-
-
 def test_handles_missing_existing_file() -> None:
     """When existing file doesn't exist, should produce single-item appcast."""
     xml = build_appcast(
@@ -310,6 +304,27 @@ def test_handles_missing_existing_file() -> None:
     items = root.findall(".//item")
     assert len(items) == 1, f"Expected 1 item, got {len(items)}"
     print("PASS: handles_missing_existing_file")
+
+
+def test_versions_before_current_are_excluded() -> None:
+    """Only the current version and older should appear, not newer versions."""
+    xml = build_appcast(
+        version="1.1.0",
+        signature="sig",
+        dmg_length=1000,
+        dmg_url="https://example.com/app.dmg",
+        changelog_text=SAMPLE_CHANGELOG,
+    )
+    root = parse(xml)
+    desc = root.find(".//item/description")
+    assert desc is not None
+    text = desc.text
+    # 1.2.0 is newer than 1.1.0 and should not appear
+    assert 'data-sparkle-version="1.2.0"' not in text
+    # 1.1.0 and older should appear
+    assert 'data-sparkle-version="1.1.0"' in text
+    assert 'data-sparkle-version="0.9.0"' in text
+    print("PASS: versions_before_current_are_excluded")
 
 
 if __name__ == "__main__":

--- a/scripts/test_seed_appcast.py
+++ b/scripts/test_seed_appcast.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-# ABOUTME: Tests for seed_appcast.py.
-# ABOUTME: Covers changelog parsing, noise filtering, and markdown-to-HTML conversion.
-"""Tests for seed_appcast.py."""
+# ABOUTME: Tests for changelog.py parsing and filtering.
+# ABOUTME: Covers CHANGELOG.md parsing, noise filtering, and markdown-to-HTML conversion.
+"""Tests for changelog.py."""
 
 import sys
 import os
 
 sys.path.insert(0, os.path.dirname(__file__))
-from seed_appcast import clean_body, parse_changelog, markdown_to_html
+import changelog
 
 
 def test_clean_body_removes_ci_entries() -> None:
@@ -16,7 +16,7 @@ def test_clean_body_removes_ci_entries() -> None:
 
 * **ci:** download appcast from previous release, not latest
 * DMG skyline clipped by Finder status bar"""
-    result = clean_body(body)
+    result = changelog.clean_body(body)
     assert "ci:" not in result
     assert "DMG skyline clipped" in result
     print("PASS: clean_body_removes_ci_entries")
@@ -29,7 +29,7 @@ def test_clean_body_removes_deps_entries() -> None:
 * **deps:** update dependency foo to v2.0
 * **deps:** update dependency bar to v3.0
 * actual bug fix here"""
-    result = clean_body(body)
+    result = changelog.clean_body(body)
     assert "deps:" not in result
     assert "actual bug fix here" in result
     print("PASS: clean_body_removes_deps_entries")
@@ -44,7 +44,7 @@ def test_clean_body_removes_empty_sections() -> None:
 ### Features
 
 * real feature here"""
-    result = clean_body(body)
+    result = changelog.clean_body(body)
     assert "Bug Fixes" not in result
     assert "Features" in result
     assert "real feature here" in result
@@ -56,9 +56,55 @@ def test_clean_body_returns_empty_when_all_filtered() -> None:
 ### Bug Fixes
 
 * **ci:** increase Node heap size for Monaco editor build"""
-    result = clean_body(body)
+    result = changelog.clean_body(body)
     assert result == ""
     print("PASS: clean_body_returns_empty_when_all_filtered")
+
+
+def test_to_html_converts_headings_and_bullets() -> None:
+    md = """\
+### Features
+
+* add cool feature
+* another feature
+
+### Bug Fixes
+
+* fix a bug"""
+    html = changelog.to_html(md)
+    assert "<h4>Features</h4>" in html
+    assert "<h4>Bug Fixes</h4>" in html
+    assert "<li>add cool feature</li>" in html
+    assert "<ul>" in html
+    print("PASS: to_html_converts_headings_and_bullets")
+
+
+def test_to_html_bolds_scope_prefixes() -> None:
+    md = "* **worktrees:** fix prune prompt"
+    html = changelog.to_html(md)
+    assert "<b>worktrees:</b>" in html
+    print("PASS: to_html_bolds_scope_prefixes")
+
+
+def test_parse_extracts_versions() -> None:
+    text = """\
+## [1.2.0](https://example.com) (2026-04-13)
+
+### Features
+
+* feature A
+
+## [1.1.0](https://example.com) (2026-04-12)
+
+### Bug Fixes
+
+* fix B"""
+    releases = changelog.parse(text)
+    assert len(releases) == 2
+    assert releases[0]["version"] == "1.2.0"
+    assert releases[1]["version"] == "1.1.0"
+    assert "feature A" in releases[0]["body"]
+    print("PASS: parse_extracts_versions")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Regenerate the cumulative Sparkle description fresh from CHANGELOG.md on every release, instead of extracting and carrying forward HTML from the existing appcast
- Extracts shared changelog parsing into `scripts/changelog.py` with regex-based markdown-to-HTML (no external dependencies)
- Filters out `ci:` and `deps:` scoped entries at the markdown level before conversion
- Simplifies `generate_appcast.py` from ~220 lines of HTML parsing hacks to ~130 lines of straightforward CHANGELOG.md reading
- Release workflow now passes `--changelog CHANGELOG.md` instead of inline Python extraction + `uvx --with markdown`

## Test plan
- [x] 11 generate_appcast tests pass (cumulative descriptions, deduplication, filtering, merging)
- [x] 7 changelog tests pass (parsing, noise filtering, HTML conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)