### PR TITLE
fix: group Monaco VSCode packages in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all Monaco/VSCode packages together since they must share the same version",
+      "matchPackageNames": [
+        "@codingame/monaco-vscode-*",
+        "monaco-editor"
+      ],
+      "groupName": "monaco-vscode"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry to `renovate.json` that groups all `@codingame/monaco-vscode-*` packages and the `monaco-editor` alias into a single update group
- Prevents Renovate from creating individual PRs that cause version mismatches between tightly coupled packages

Closes #436

## Context
Renovate updated each `@codingame/monaco-vscode-*` package individually but didn't recognize `monaco-editor` (declared as `npm:@codingame/monaco-vscode-editor-api@30.0.0`) as part of the same group. These packages all need to be on the same version or the editor breaks.

## Test plan
- [ ] Verify Renovate's next run produces a single grouped PR for Monaco packages
- [ ] Confirm editor view loads correctly after the grouped update

🤖 Generated with [Claude Code](https://claude.com/claude-code)