### PR TITLE
fix: enable extended-keys in tmux config for Shift+Enter support

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -33,7 +33,9 @@ enum TmuxSession {
         set -g history-limit 50000
         set -g escape-time 0
         set -g allow-passthrough on
+        set -g extended-keys on
         set -g default-terminal "xterm-256color"
+        set -ga terminal-features ',*:extkeys'
         set -ga terminal-overrides ',*:smcup@:rmcup@'
         set -g alternate-screen off
         set -g aggressive-resize on


### PR DESCRIPTION
## Summary
- Shift+Enter doesn't work in the Coding Agent view when tmux mode is enabled — both Shift+Enter and Enter arrive as `\r`, so Claude Code can't distinguish them.
- Adds `set -g extended-keys on` and `set -ga terminal-features ',*:extkeys'` to the generated tmux config so tmux requests and forwards xterm-style modified key sequences from Ghostty.

## Test plan
- [ ] Kill existing tmux server: `tmux -L factoryfloor kill-server`
- [ ] Delete cached config: `rm -f ~/Library/Caches/factoryfloor/tmux.conf`
- [ ] Launch app with tmux mode enabled
- [ ] Open a workstream's Coding Agent tab
- [ ] Press Shift+Enter — should insert a newline, not submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)