### PR TITLE
feat(telemetry): enrich Umami payloads and broaden tracked events

### DIFF
--- a/Sources/Models/Telemetry.swift
+++ b/Sources/Models/Telemetry.swift
@@ -37,7 +37,7 @@ final class Telemetry {
         guard isEnabled else { return }
 
         let screen = NSScreen.main?.frame.size
-        let version = AppConstants.version
+        let userAgent = Self.userAgent
 
         Task.detached { [endpoint, websiteID, hostname, logger] in
             var payload: [String: Any] = [
@@ -66,7 +66,7 @@ final class Telemetry {
             var request = URLRequest(url: endpoint)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("Mozilla/5.0 (Macintosh; macOS) FactoryFloor/\(version)", forHTTPHeaderField: "User-Agent")
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             request.httpBody = jsonData
 
             do {
@@ -95,4 +95,18 @@ final class Telemetry {
         #endif
         return info
     }
+
+    private static let userAgent: String = {
+        let os = ProcessInfo.processInfo.operatingSystemVersion
+        let osVersion = "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"
+        #if arch(arm64)
+            let arch = "arm64"
+        #elseif arch(x86_64)
+            let arch = "x86_64"
+        #else
+            let arch = "unknown"
+        #endif
+        let locale = Locale.current.identifier
+        return "FactoryFloor/\(AppConstants.version) (Macintosh; macOS \(osVersion); \(arch); \(locale))"
+    }()
 }

--- a/Sources/Models/Telemetry.swift
+++ b/Sources/Models/Telemetry.swift
@@ -15,7 +15,11 @@ final class Telemetry {
     private let hostname = "app.factory-floor.com"
 
     var isEnabled: Bool {
-        UserDefaults.standard.object(forKey: "factoryfloor.telemetryEnabled") as? Bool ?? true
+        #if DEBUG
+            return false
+        #else
+            return UserDefaults.standard.object(forKey: "factoryfloor.telemetryEnabled") as? Bool ?? true
+        #endif
     }
 
     /// Anonymous installation identifier, generated on first launch.
@@ -89,17 +93,11 @@ final class Telemetry {
 
     private func systemInfo() -> [String: String] {
         let os = ProcessInfo.processInfo.operatingSystemVersion
-        var info: [String: String] = [
+        return [
             "version": AppConstants.version,
             "os_version": "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)",
             "locale": Locale.current.identifier,
         ]
-        #if DEBUG
-            info["build"] = "debug"
-        #else
-            info["build"] = "release"
-        #endif
-        return info
     }
 
     private static let userAgent: String = {

--- a/Sources/Models/Telemetry.swift
+++ b/Sources/Models/Telemetry.swift
@@ -69,6 +69,7 @@ final class Telemetry {
 
             var request = URLRequest(url: endpoint)
             request.httpMethod = "POST"
+            request.timeoutInterval = 5
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             request.httpBody = jsonData

--- a/Sources/Models/Telemetry.swift
+++ b/Sources/Models/Telemetry.swift
@@ -38,6 +38,7 @@ final class Telemetry {
 
         let screen = NSScreen.main?.frame.size
         let userAgent = Self.userAgent
+        let id = installationID
 
         Task.detached { [endpoint, websiteID, hostname, logger] in
             var payload: [String: Any] = [
@@ -46,6 +47,7 @@ final class Telemetry {
                 "url": url,
                 "website": websiteID,
                 "name": event,
+                "id": id,
             ]
 
             if let title {
@@ -91,7 +93,6 @@ final class Telemetry {
             "version": AppConstants.version,
             "os_version": "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)",
             "locale": Locale.current.identifier,
-            "installation_id": installationID,
         ]
         #if DEBUG
             info["build"] = "debug"

--- a/Sources/Models/Telemetry.swift
+++ b/Sources/Models/Telemetry.swift
@@ -30,10 +30,10 @@ final class Telemetry {
     }
 
     func trackLaunch() {
-        track("app_launch", url: "/app/launch", data: systemInfo())
+        track("app_launch", url: "/app/launch", title: "App Launch", data: systemInfo())
     }
 
-    func track(_ event: String, url: String = "/app", data: [String: String] = [:]) {
+    func track(_ event: String, url: String = "/app", title: String? = nil, data: [String: String] = [:]) {
         guard isEnabled else { return }
 
         let screen = NSScreen.main?.frame.size
@@ -47,6 +47,10 @@ final class Telemetry {
                 "website": websiteID,
                 "name": event,
             ]
+
+            if let title {
+                payload["title"] = title
+            }
 
             if let screen {
                 payload["screen"] = "\(Int(screen.width))x\(Int(screen.height))"

--- a/Sources/Models/WorkstreamArchiver.swift
+++ b/Sources/Models/WorkstreamArchiver.swift
@@ -64,6 +64,7 @@ enum WorkstreamArchiver {
             let projName = project.name
             // Capture the branch name before the worktree is removed
             let branchName = GitOperations.currentBranch(at: worktreePath)
+            Telemetry.shared.track("workstream_archived", url: "/workstream/archive", title: "Workstream Archived")
             Task.detached {
                 ScriptConfig.runTeardown(in: worktreePath, projectDirectory: projectDir)
                 GitOperations.removeWorktree(projectPath: projectDir, worktreePath: worktreePath)

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -412,6 +412,7 @@ struct ContentView: View {
                     ProjectStore.save(projects)
                     appEnvironment.refreshPathValidity(projects: projects)
                     logger.warning("[FF] workstreamWorktreeReady: updated \(workstreamID, privacy: .public) with path \(worktreePath, privacy: .public)")
+                    Telemetry.shared.track("workstream_created", url: "/workstream/create", title: "Workstream Created")
                     return
                 }
             }

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -215,6 +215,14 @@ struct SettingsView: View {
                     description: "Coding Agent sessions persist across app restarts. The Terminal tab is not affected. Sessions are lost on system restart."
                 )
                 .disabled(!appEnv.toolStatus.tmux.isInstalled)
+                .onChange(of: tmuxMode) { _, newValue in
+                    Telemetry.shared.track(
+                        "setting_changed",
+                        url: "/settings/tmux-mode",
+                        title: "Tmux Mode Toggled",
+                        data: ["setting": "tmux_mode", "value": newValue ? "on" : "off"]
+                    )
+                }
 
                 if !appEnv.toolStatus.tmux.isInstalled {
                     Text("Requires tmux to be installed.")

--- a/Sources/Views/TerminalContainerView.swift
+++ b/Sources/Views/TerminalContainerView.swift
@@ -920,6 +920,7 @@ struct TerminalContainerView: View {
         tabs.append(tab)
         activeTab = tab
         saveTabSnapshot()
+        Telemetry.shared.track("tab_opened", url: "/tab/terminal", title: "Terminal Tab", data: ["kind": "terminal"])
     }
 
     private func addBrowser() {
@@ -929,6 +930,7 @@ struct TerminalContainerView: View {
         tabs.append(tab)
         activeTab = tab
         saveTabSnapshot()
+        Telemetry.shared.track("tab_opened", url: "/tab/browser", title: "Browser Tab", data: ["kind": "browser"])
     }
 
     private func openEditor() {
@@ -948,6 +950,7 @@ struct TerminalContainerView: View {
         activeTab = tab
         startFileTreeWatcherIfNeeded()
         saveTabSnapshot()
+        Telemetry.shared.track("tab_opened", url: "/tab/editor", title: "Editor Tab", data: ["kind": "editor"])
     }
 
     private func startFileTreeWatcherIfNeeded() {


### PR DESCRIPTION
## Summary
- Enrich User-Agent with macOS version, architecture, and locale so Umami dashboards populate device columns
- Add `title`, top-level `id` (for session continuity), and a 5 s request timeout to the payload
- Short-circuit telemetry in DEBUG builds so developer usage no longer pollutes the dashboard
- Broaden tracked events beyond `app_launch`: workstream create/archive, new terminal/browser/editor tabs, and tmux-mode toggle

Inspired by [codeskraps.com's Umami-for-mobile write-up](https://codeskraps.com/posts/2026/umami_mobile_analytics/); skipped its clean-architecture split as unnecessary for our ~100-line module.

## Test plan
- [x] `./scripts/dev.sh build` succeeds (debug)
- [x] `./scripts/dev.sh test` passes (193 tests)
- [ ] Release build sanity check: verify a single `app_launch` POST to `meta.factory-floor.com/api/send` in a packet capture, with the new UA, title, and id fields
- [ ] Trigger each new event manually (create + archive workstream, open terminal/browser/editor tabs, toggle Tmux Mode) and confirm they appear in the Umami dashboard
- [ ] Confirm DEBUG builds do **not** emit requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)