### PR TITLE
perf: reduce SwiftUI main-thread churn from AppEnvironment

### DIFF
--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -190,8 +190,21 @@ final class AppEnvironment: ObservableObject {
         worktreeStateCache[path] ?? WorktreeState()
     }
 
-    /// Refresh working tree state for a single worktree path.
+    private var worktreeStateTimestamps: [String: Date] = [:]
+    private static let worktreeStateRefreshInterval: TimeInterval = 5
+
+    /// Refresh working tree state for a single worktree path. Throttled to once
+    /// every `worktreeStateRefreshInterval` seconds per path so chatty terminal
+    /// activity doesn't spawn git subprocesses on every keystroke.
     func refreshWorktreeState(for worktreePath: String, projectDirectory: String) {
+        let now = Date()
+        if let last = worktreeStateTimestamps[worktreePath],
+           now.timeIntervalSince(last) < Self.worktreeStateRefreshInterval
+        {
+            return
+        }
+        worktreeStateTimestamps[worktreePath] = now
+
         let path = worktreePath
         let projectDir = projectDirectory
         Task.detached {

--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -55,6 +55,7 @@ final class AppEnvironment: ObservableObject {
     /// Send a single `objectWillChange` notification around a batch of mutations.
     /// Callers should batch every coherent refresh cycle into one call so subscribers
     /// invalidate once per transaction rather than once per property.
+    @discardableResult
     private func commitChanges<T>(_ body: () -> T) -> T {
         objectWillChange.send()
         return body()

--- a/Sources/Models/Environment.swift
+++ b/Sources/Models/Environment.swift
@@ -15,52 +15,64 @@ struct WorktreeState {
 
 @MainActor
 final class AppEnvironment: ObservableObject {
-    @Published var toolStatus = ToolStatus()
-    @Published var installedTerminals: [AppInfo] = []
-    @Published var installedBrowsers: [AppInfo] = []
-    @Published var isDetecting = false
+    // Published backing values are mutated through `commitChanges` so a batch of
+    // cache updates produces a single `objectWillChange` notification.
+    var toolStatus = ToolStatus()
+    var installedTerminals: [AppInfo] = []
+    var installedBrowsers: [AppInfo] = []
+    var isDetecting = false
 
     // Cached repo info per directory, refreshed asynchronously
-    @Published private var repoInfoCache: [String: GitRepoInfo] = [:]
+    private var repoInfoCache: [String: GitRepoInfo] = [:]
     private var repoInfoTimestamps: [String: Date] = [:]
 
     /// Worktree path validity cache
-    @Published private var pathValidityCache: [String: Bool] = [:]
+    private var pathValidityCache: [String: Bool] = [:]
 
     /// Branch name cache per worktree path
-    @Published private var branchNameCache: [String: String] = [:]
+    private var branchNameCache: [String: String] = [:]
 
     /// Git repo detection cache per project directory
-    @Published private var gitRepoCache: [String: Bool] = [:]
+    private var gitRepoCache: [String: Bool] = [:]
 
     /// Working tree state cache per worktree path
-    @Published private var worktreeStateCache: [String: WorktreeState] = [:]
+    private var worktreeStateCache: [String: WorktreeState] = [:]
 
     /// Active port cache per workstream ID
-    @Published private var activePortCache: Set<UUID> = []
+    private var activePortCache: Set<UUID> = []
 
     /// Task description cache per worktree path
-    @Published private var taskDescriptionCache: [String: String] = [:]
+    private var taskDescriptionCache: [String: String] = [:]
 
     /// GitHub remote detection cache per project directory (lightweight git check)
-    @Published private var githubRemoteCache: [String: Bool] = [:]
+    private var githubRemoteCache: [String: Bool] = [:]
 
     // GitHub info cache
-    @Published private var githubRepoCache: [String: GitHubRepoInfo] = [:]
-    @Published private var githubPRCache: [String: [GitHubPR]] = [:]
-    @Published private var githubBranchPRCache: [String: GitHubPR] = [:] // key: "dir|branch"
+    private var githubRepoCache: [String: GitHubRepoInfo] = [:]
+    private var githubPRCache: [String: [GitHubPR]] = [:]
+    private var githubBranchPRCache: [String: GitHubPR] = [:] // key: "dir|branch"
+
+    /// Send a single `objectWillChange` notification around a batch of mutations.
+    /// Callers should batch every coherent refresh cycle into one call so subscribers
+    /// invalidate once per transaction rather than once per property.
+    private func commitChanges<T>(_ body: () -> T) -> T {
+        objectWillChange.send()
+        return body()
+    }
 
     func refresh() {
-        isDetecting = true
+        commitChanges { isDetecting = true }
         Task.detached {
             let tools = ToolStatus.detect()
             let terminals = AppInfo.detectTerminals()
             let browsers = AppInfo.detectBrowsers()
             await MainActor.run {
-                self.toolStatus = tools
-                self.installedTerminals = terminals
-                self.installedBrowsers = browsers
-                self.isDetecting = false
+                self.commitChanges {
+                    self.toolStatus = tools
+                    self.installedTerminals = terminals
+                    self.installedBrowsers = browsers
+                    self.isDetecting = false
+                }
             }
         }
     }
@@ -107,7 +119,9 @@ final class AppEnvironment: ObservableObject {
         Task.detached {
             let info = GitOperations.repoInfo(at: directory)
             await MainActor.run {
-                self.repoInfoCache[directory] = info
+                self.commitChanges {
+                    self.repoInfoCache[directory] = info
+                }
             }
         }
     }
@@ -131,7 +145,9 @@ final class AppEnvironment: ObservableObject {
             Task.detached {
                 let info = GitOperations.repoInfo(at: dir)
                 await MainActor.run {
-                    self.repoInfoCache[dir] = info
+                    self.commitChanges {
+                        self.repoInfoCache[dir] = info
+                    }
                 }
             }
         }
@@ -191,7 +207,9 @@ final class AppEnvironment: ObservableObject {
     private func deferWorktreeStateUpdate(_ state: WorktreeState, for path: String) {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 50_000_000)
-            self.worktreeStateCache[path] = state
+            self.commitChanges {
+                self.worktreeStateCache[path] = state
+            }
         }
     }
 
@@ -205,7 +223,7 @@ final class AppEnvironment: ObservableObject {
     }
 
     /// Returns IDs of projects whose directories no longer exist.
-    @Published var missingProjectIDs: Set<UUID> = []
+    var missingProjectIDs: Set<UUID> = []
 
     func refreshPathValidity(projects: [Project]) {
         Task.detached {
@@ -306,14 +324,16 @@ final class AppEnvironment: ObservableObject {
             }
 
             await MainActor.run {
-                self.pathValidityCache.merge(results) { _, new in new }
-                self.branchNameCache.merge(branches) { _, new in new }
-                self.missingProjectIDs = missing
-                self.gitRepoCache.merge(gitRepoResults) { _, new in new }
-                self.githubRemoteCache.merge(githubRemoteResults) { _, new in new }
-                self.worktreeStateCache.merge(worktreeStates) { _, new in new }
-                self.activePortCache = portResults
-                self.taskDescriptionCache = descriptionResults
+                self.commitChanges {
+                    self.pathValidityCache.merge(results) { _, new in new }
+                    self.branchNameCache.merge(branches) { _, new in new }
+                    self.missingProjectIDs = missing
+                    self.gitRepoCache.merge(gitRepoResults) { _, new in new }
+                    self.githubRemoteCache.merge(githubRemoteResults) { _, new in new }
+                    self.worktreeStateCache.merge(worktreeStates) { _, new in new }
+                    self.activePortCache = portResults
+                    self.taskDescriptionCache = descriptionResults
+                }
             }
         }
     }
@@ -337,7 +357,9 @@ final class AppEnvironment: ObservableObject {
     }
 
     func clearBranchPR(for directory: String, branch: String) {
-        githubBranchPRCache.removeValue(forKey: "\(directory)|\(branch)")
+        commitChanges {
+            githubBranchPRCache.removeValue(forKey: "\(directory)|\(branch)")
+        }
     }
 
     func refreshGitHubInfo(for directory: String, branch: String? = nil) {
@@ -356,10 +378,12 @@ final class AppEnvironment: ObservableObject {
             }
 
             await MainActor.run {
-                if let repo { self.githubRepoCache[directory] = repo }
-                self.githubPRCache[directory] = prs
-                if let branch, let pr = branchPR {
-                    self.githubBranchPRCache["\(directory)|\(branch)"] = pr
+                self.commitChanges {
+                    if let repo { self.githubRepoCache[directory] = repo }
+                    self.githubPRCache[directory] = prs
+                    if let branch, let pr = branchPR {
+                        self.githubBranchPRCache["\(directory)|\(branch)"] = pr
+                    }
                 }
             }
         }
@@ -377,12 +401,14 @@ final class AppEnvironment: ObservableObject {
             let prs = GitHubOperations.openPRs(ghPath: ghPath, at: directory, limit: 100)
             let prsByBranch = Dictionary(prs.map { ($0.branch, $0) }, uniquingKeysWith: { first, _ in first })
             await MainActor.run {
-                for branch in branches {
-                    let key = "\(directory)|\(branch)"
-                    if let pr = prsByBranch[branch] {
-                        self.githubBranchPRCache[key] = pr
-                    } else {
-                        self.githubBranchPRCache.removeValue(forKey: key)
+                self.commitChanges {
+                    for branch in branches {
+                        let key = "\(directory)|\(branch)"
+                        if let pr = prsByBranch[branch] {
+                            self.githubBranchPRCache[key] = pr
+                        } else {
+                            self.githubBranchPRCache.removeValue(forKey: key)
+                        }
                     }
                 }
             }
@@ -446,18 +472,20 @@ final class AppEnvironment: ObservableObject {
                 let prsByBranch = Dictionary(prs.map { ($0.branch, $0) }, uniquingKeysWith: { first, _ in first })
 
                 await MainActor.run {
-                    for branch in branches {
-                        let key = "\(dir)|\(branch)"
-                        if let pr = prsByBranch[branch] {
-                            self.githubBranchPRCache[key] = pr
-                        } else if cachedStates[key] == "MERGED" {
-                            // Already cached as merged, no need to re-fetch
-                        } else if cachedStates[key] != nil {
-                            // Had an open PR that's no longer open, check if merged
-                            mergedLookups.append((dir: dir, branch: branch, key: key))
-                            self.githubBranchPRCache.removeValue(forKey: key)
-                        } else {
-                            // Never had a cached PR, nothing to do
+                    self.commitChanges {
+                        for branch in branches {
+                            let key = "\(dir)|\(branch)"
+                            if let pr = prsByBranch[branch] {
+                                self.githubBranchPRCache[key] = pr
+                            } else if cachedStates[key] == "MERGED" {
+                                // Already cached as merged, no need to re-fetch
+                            } else if cachedStates[key] != nil {
+                                // Had an open PR that's no longer open, check if merged
+                                mergedLookups.append((dir: dir, branch: branch, key: key))
+                                self.githubBranchPRCache.removeValue(forKey: key)
+                            } else {
+                                // Never had a cached PR, nothing to do
+                            }
                         }
                     }
                 }
@@ -475,7 +503,9 @@ final class AppEnvironment: ObservableObject {
                     for await (key, pr) in group {
                         if let pr {
                             await MainActor.run {
-                                self.githubBranchPRCache[key] = pr
+                                self.commitChanges {
+                                    self.githubBranchPRCache[key] = pr
+                                }
                             }
                         }
                     }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -44,6 +44,7 @@ struct ProjectSidebar: View {
     @State private var purgeWarningMessage: String?
     @State private var expandedProjects: Set<UUID> = SidebarState.loadExpanded()
     @State private var cachedSortedIDs: [UUID] = []
+    @State private var cachedSortedWorkstreamIDs: [UUID: [UUID]] = [:]
     @State private var cachedProjectIndex: [UUID: Int] = [:]
     @State private var cachedWorkstreamIndex: [UUID: (Int, Int)] = [:]
     @State private var showWorktreeError = false
@@ -62,12 +63,21 @@ struct ProjectSidebar: View {
     private func rebuildIndices() {
         cachedProjectIndex = Dictionary(uniqueKeysWithValues: projects.enumerated().map { ($1.id, $0) })
         var wsIndex: [UUID: (Int, Int)] = [:]
+        var sortedWS: [UUID: [UUID]] = [:]
         for (pi, project) in projects.enumerated() {
             for (wi, ws) in project.workstreams.enumerated() {
                 wsIndex[ws.id] = (pi, wi)
             }
+            sortedWS[project.id] = project.workstreams
+                .sorted { $0.lastAccessedAt > $1.lastAccessedAt }
+                .map(\.id)
         }
         cachedWorkstreamIndex = wsIndex
+        cachedSortedWorkstreamIDs = sortedWS
+    }
+
+    private func totalWorkstreamCount() -> Int {
+        projects.reduce(0) { $0 + $1.workstreams.count }
     }
 
     private func projectBinding(for id: UUID) -> Binding<Project> {
@@ -135,27 +145,33 @@ struct ProjectSidebar: View {
             .tag(SidebarSelection.project(project.id))
 
             if hasChildren && expandedProjects.contains(project.id) {
-                let sortedWS = project.workstreams.sorted { $0.lastAccessedAt > $1.lastAccessedAt }
-                ForEach(sortedWS) { workstream in
-                    let branch = appEnv.branchName(for: workstream.worktreePath)
-                    let pr = branch.flatMap { appEnv.githubPR(for: project.directory, branch: $0) }
-                    WorkstreamRow(
-                        name: workstream.name,
-                        branchName: branch,
-                        worktreePath: workstream.worktreePath,
-                        isPathValid: appEnv.isPathValid(workstream.worktreePath),
-                        isActive: activityTracker.isActive(workstream.id),
-                        hasActivePort: appEnv.hasActivePort(workstream.id),
-                        githubURL: appEnv.githubURL(for: project.directory),
-                        taskDescription: appEnv.taskDescription(for: workstream.worktreePath),
-                        prTitle: pr?.title,
-                        prNumber: pr?.number,
-                        prState: pr?.state,
-                        onRemove: { workstreamToRemove = workstream.id },
-                        onPurge: { confirmPurge(workstream) }
-                    )
-                    .tag(SidebarSelection.workstream(workstream.id))
-                    .padding(.leading, 28)
+                let sortedWorkstreamIDs = cachedSortedWorkstreamIDs[project.id] ?? project.workstreams.map(\.id)
+                ForEach(sortedWorkstreamIDs, id: \.self) { workstreamID in
+                    if let (pIdx, wIdx) = cachedWorkstreamIndex[workstreamID],
+                       projects.indices.contains(pIdx),
+                       projects[pIdx].workstreams.indices.contains(wIdx)
+                    {
+                        let workstream = projects[pIdx].workstreams[wIdx]
+                        let branch = appEnv.branchName(for: workstream.worktreePath)
+                        let pr = branch.flatMap { appEnv.githubPR(for: project.directory, branch: $0) }
+                        WorkstreamRow(
+                            name: workstream.name,
+                            branchName: branch,
+                            worktreePath: workstream.worktreePath,
+                            isPathValid: appEnv.isPathValid(workstream.worktreePath),
+                            isActive: activityTracker.isActive(workstream.id),
+                            hasActivePort: appEnv.hasActivePort(workstream.id),
+                            githubURL: appEnv.githubURL(for: project.directory),
+                            taskDescription: appEnv.taskDescription(for: workstream.worktreePath),
+                            prTitle: pr?.title,
+                            prNumber: pr?.number,
+                            prState: pr?.state,
+                            onRemove: { workstreamToRemove = workstream.id },
+                            onPurge: { confirmPurge(workstream) }
+                        )
+                        .tag(SidebarSelection.workstream(workstream.id))
+                        .padding(.leading, 28)
+                    }
                 }
             }
         }
@@ -365,6 +381,9 @@ struct ProjectSidebar: View {
             onProjectsChanged()
             if sortOrder == .recent {
                 cachedSortedIDs = recomputeSortedIDs()
+                cachedSortedWorkstreamIDs[projects[pi].id] = projects[pi].workstreams
+                    .sorted { $0.lastAccessedAt > $1.lastAccessedAt }
+                    .map(\.id)
             }
         }
         .onAppear {
@@ -377,7 +396,7 @@ struct ProjectSidebar: View {
             cachedSortedIDs = recomputeSortedIDs()
             rebuildIndices()
         }
-        .onChange(of: projects.flatMap(\.workstreams).map(\.id)) { _, _ in
+        .onChange(of: totalWorkstreamCount()) { _, _ in
             rebuildIndices()
         }
         .overlay {


### PR DESCRIPTION
## Summary
Three targeted fixes for the App Hang cluster dominated by [FACTORY-FLOOR-7](https://all-tuner-labs.sentry.io/issues/FACTORY-FLOOR-7) (645 events / 38 users, culprit `FF2App.$main`, stack ends in SwiftUI `GraphHost.flushTransactions`).

- **Batch AppEnvironment publishes** — `refreshPathValidity` wrote 7 `@Published` dictionaries sequentially, and `refreshAllBranchPRs` wrote per-branch in a loop. Drop `@Published` from the caches and route mutations through a single `commitChanges { }` helper so subscribers invalidate once per transaction rather than once per property.
- **Throttle `refreshWorktreeState`** — called on every `activeTab` change and every `.terminalActivity` notification with no throttle; a chatty Coding Agent tab could spawn 4 git subprocesses per burst. Matches the existing 5s throttle on `refreshRepoInfo`.
- **Memoise the per-project workstream sort** in `ProjectSidebar.projectRows()` — previously re-sorted every expanded project on every body evaluation. Also replaces a `.onChange(of: projects.flatMap(\.workstreams).map(\.id))` comparand that allocated `[UUID]` on every invalidation.

## Test plan
- [ ] Clean build succeeds (`./scripts/dev.sh build`) ✅
- [ ] Sidebar renders projects and workstreams in the expected order
- [ ] `lastAccessedAt`-based reordering still works: trigger activity in a workstream, confirm it floats to the top when sort = Recent
- [ ] Switch between workstreams rapidly; confirm worktree state icons still update (within 5s throttle)
- [ ] Create/delete/purge a workstream; confirm sidebar indices rebuild correctly
- [ ] Watch Sentry [FACTORY-FLOOR-7](https://all-tuner-labs.sentry.io/issues/FACTORY-FLOOR-7) event rate post-release 0.1.76

🤖 Generated with [Claude Code](https://claude.com/claude-code)