### PR TITLE
ci: allow revert as a conventional PR title type

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -26,6 +26,7 @@ jobs:
             perf
             ci
             build
+            revert
           requireScope: false
           subjectPattern: ^.+$
           subjectPatternError: |


### PR DESCRIPTION
## Summary

Adds `revert` to the allowed types in the PR title check. `git revert` produces commits like `Revert "feat: foo"` and Conventional Commits lists `revert` as a standard type, so revert PRs would otherwise fail the title check unnecessarily.

Followup to the recent PR title check rollout.

## Test plan

- [ ] Workflow file is syntactically valid
- [ ] Opening a PR with `revert: ...` title passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)