### PR TITLE
feat(sidebar): highlight workstreams when agent needs attention

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/Sources/Models/NameGenerator.swift
+++ b/Sources/Models/NameGenerator.swift
@@ -35,7 +35,7 @@ enum NameGenerator {
     /// Generate a unique name that doesn't collide with existing names.
     static func generate(avoiding existing: Set<String>) -> String {
         // Total combinations: 45 * 40 * 70 = 126,000
-        for _ in 0..<100 {
+        for _ in 0 ..< 100 {
             let name = [
                 operations.randomElement()!,
                 adjectives.randomElement()!,

--- a/Sources/Models/PathUtilities.swift
+++ b/Sources/Models/PathUtilities.swift
@@ -23,11 +23,15 @@ func derivedUUID(from base: UUID, salt: String) -> UUID {
 }
 
 extension String: @retroactive Identifiable {
-    public var id: String { self }
+    public var id: String {
+        self
+    }
 }
 
 extension UUID: @retroactive Identifiable {
-    public var id: UUID { self }
+    public var id: UUID {
+        self
+    }
 }
 
 extension String {

--- a/Sources/Models/PortDetector.swift
+++ b/Sources/Models/PortDetector.swift
@@ -13,7 +13,7 @@ final class PortDetector: ObservableObject, @unchecked Sendable {
 
     init(workstreamID: UUID) {
         self.workstreamID = workstreamID
-        self.queue = DispatchQueue(label: "factoryfloor.port-detector.\(workstreamID.uuidString.lowercased())")
+        queue = DispatchQueue(label: "factoryfloor.port-detector.\(workstreamID.uuidString.lowercased())")
         start()
     }
 

--- a/Sources/Models/Project.swift
+++ b/Sources/Models/Project.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-struct Workstream: Identifiable, Hashable, Codable, Sendable {
+struct Workstream: Identifiable, Hashable, Codable {
     let id: UUID
     var name: String
     var worktreePath: String?
@@ -33,7 +33,7 @@ struct Workstream: Identifiable, Hashable, Codable, Sendable {
     }
 }
 
-struct Project: Identifiable, Hashable, Codable, Sendable {
+struct Project: Identifiable, Hashable, Codable {
     let id: UUID
     var name: String
     var directory: String
@@ -57,7 +57,7 @@ struct Project: Identifiable, Hashable, Codable, Sendable {
     }
 }
 
-enum ProjectSortOrder: String, CaseIterable, Sendable {
+enum ProjectSortOrder: String, CaseIterable {
     case recent = "Recent"
     case alphabetical = "A-Z"
 }

--- a/Sources/Models/RunState.swift
+++ b/Sources/Models/RunState.swift
@@ -1,17 +1,17 @@
 // ABOUTME: Shared run-state types for ff-run and the app-side port monitor.
 // ABOUTME: Encodes detected localhost ports, selection rules, and state-file persistence.
 
-import Foundation
 import Darwin
+import Foundation
 
-enum RunStateStatus: String, Codable, Sendable {
+enum RunStateStatus: String, Codable {
     case starting
     case running
     case stopped
     case crashed
 }
 
-struct RunStateSnapshot: Codable, Sendable {
+struct RunStateSnapshot: Codable {
     let pid: Int32
     let status: RunStateStatus
     let detectedPorts: [Int]
@@ -19,12 +19,12 @@ struct RunStateSnapshot: Codable, Sendable {
     let startedAt: Date
 }
 
-struct PortSelectionResult: Sendable {
+struct PortSelectionResult {
     let detectedPorts: [Int]
     let selectedPort: Int?
 }
 
-struct PortSelectionTracker: Sendable {
+struct PortSelectionTracker {
     let expectedPort: Int?
     private var lastCandidate: Int?
     private var candidateMatches = 0
@@ -43,8 +43,9 @@ struct PortSelectionTracker: Sendable {
 
         let candidate = candidatePort(currentPorts: currentPorts)
 
-        if self.selectedPort == nil,
-           let candidate {
+        if selectedPort == nil,
+           let candidate
+        {
             if candidate == lastCandidate {
                 candidateMatches += 1
             } else {
@@ -54,7 +55,7 @@ struct PortSelectionTracker: Sendable {
             if candidateMatches >= 2 {
                 selectedPort = candidate
             }
-        } else if self.selectedPort == nil {
+        } else if selectedPort == nil {
             lastCandidate = nil
             candidateMatches = 0
         }
@@ -71,7 +72,8 @@ struct PortSelectionTracker: Sendable {
         }
         if currentPorts.count > 1,
            let expectedPort,
-           currentPorts.contains(expectedPort) {
+           currentPorts.contains(expectedPort)
+        {
             return expectedPort
         }
         return nil
@@ -81,7 +83,8 @@ struct PortSelectionTracker: Sendable {
         let sortedPorts = currentPorts.sorted()
         guard let preferredPort,
               currentPorts.contains(preferredPort),
-              currentPorts.count > 1 else {
+              currentPorts.count > 1
+        else {
             return sortedPorts
         }
 
@@ -104,7 +107,8 @@ enum RunStateStore {
 
     static func loadValidated(for workstreamID: UUID) -> RunStateSnapshot? {
         guard let state = load(for: workstreamID),
-              isProcessRunning(pid: state.pid) else {
+              isProcessRunning(pid: state.pid)
+        else {
             return nil
         }
         return state

--- a/Sources/Models/WorkstreamActivityTracker.swift
+++ b/Sources/Models/WorkstreamActivityTracker.swift
@@ -7,6 +7,7 @@ import Foundation
 @MainActor
 final class WorkstreamActivityTracker: ObservableObject {
     @Published private(set) var activeWorkstreamIDs: Set<UUID> = []
+    @Published private(set) var needsAttentionIDs: Set<UUID> = []
 
     /// How long after the last activity a workstream is considered active.
     private let activityTimeout: TimeInterval = 5
@@ -24,6 +25,22 @@ final class WorkstreamActivityTracker: ObservableObject {
             }
             .store(in: &cancellables)
 
+        NotificationCenter.default.publisher(for: .terminalNeedsAttention)
+            .compactMap { $0.object as? UUID }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] wsID in
+                self?.recordAttention(for: wsID)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .terminalClearAttention)
+            .compactMap { $0.object as? UUID }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] wsID in
+                self?.clearAttention(for: wsID)
+            }
+            .store(in: &cancellables)
+
         pruneTimer = Timer.publish(every: 2, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
@@ -35,6 +52,19 @@ final class WorkstreamActivityTracker: ObservableObject {
         lastActivityTimes[workstreamID] = Date()
         if !activeWorkstreamIDs.contains(workstreamID) {
             activeWorkstreamIDs.insert(workstreamID)
+        }
+    }
+
+    private func recordAttention(for workstreamID: UUID) {
+        if !needsAttentionIDs.contains(workstreamID) {
+            needsAttentionIDs.insert(workstreamID)
+            objectWillChange.send()
+        }
+    }
+
+    func clearAttention(for workstreamID: UUID) {
+        if needsAttentionIDs.remove(workstreamID) != nil {
+            objectWillChange.send()
         }
     }
 
@@ -55,5 +85,9 @@ final class WorkstreamActivityTracker: ObservableObject {
 
     func isActive(_ workstreamID: UUID) -> Bool {
         activeWorkstreamIDs.contains(workstreamID)
+    }
+
+    func needsAttention(_ workstreamID: UUID) -> Bool {
+        needsAttentionIDs.contains(workstreamID)
     }
 }

--- a/Sources/Terminal/TerminalApp.swift
+++ b/Sources/Terminal/TerminalApp.swift
@@ -76,6 +76,14 @@ private func handleTerminalAction(
         sendDesktopNotification(title: title, body: body, suppressWhenActive: false)
         return true
     case GHOSTTY_ACTION_RING_BELL:
+        guard let view = TerminalView.view(for: target.target.surface),
+              let wsID = view.workstreamID else { return false }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .terminalNeedsAttention,
+                object: wsID
+            )
+        }
         sendDesktopNotification(title: AppConstants.appName, body: "Terminal bell", suppressWhenActive: true)
         return true
     case GHOSTTY_ACTION_SHOW_CHILD_EXITED:

--- a/Sources/Terminal/TerminalView.swift
+++ b/Sources/Terminal/TerminalView.swift
@@ -9,6 +9,8 @@ private let logger = Logger(subsystem: "factoryfloor", category: "terminal-view"
 extension Notification.Name {
     static let terminalChildExited = Notification.Name("factoryfloor.terminalChildExited")
     static let terminalActivity = Notification.Name("ff2.terminalActivity")
+    static let terminalNeedsAttention = Notification.Name("ff2.terminalNeedsAttention")
+    static let terminalClearAttention = Notification.Name("ff2.terminalClearAttention")
 }
 
 @MainActor
@@ -167,6 +169,9 @@ final class TerminalView: NSView {
         let result = super.becomeFirstResponder()
         if result, let surface {
             ghostty_surface_set_focus(surface, true)
+            if let workstreamID {
+                NotificationCenter.default.post(name: .terminalClearAttention, object: workstreamID)
+            }
         }
         return result
     }
@@ -334,6 +339,8 @@ final class TerminalView: NSView {
     /// Debounced activity notification (at most once per 30 seconds).
     private func reportActivity() {
         guard let workstreamID else { return }
+        NotificationCenter.default.post(name: .terminalClearAttention, object: workstreamID)
+
         guard activityDebounceWork == nil else { return }
         NotificationCenter.default.post(name: .terminalActivity, object: workstreamID)
         let work = DispatchWorkItem { [weak self] in
@@ -611,6 +618,9 @@ final class TerminalView: NSView {
         // Claim first responder so this surface gets keyboard input
         window?.makeFirstResponder(self)
         guard let surface else { return }
+        if let workstreamID {
+            NotificationCenter.default.post(name: .terminalClearAttention, object: workstreamID)
+        }
         let mods = Self.eventMods(event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods)
     }

--- a/Sources/Views/PoblenouSkyline.swift
+++ b/Sources/Views/PoblenouSkyline.swift
@@ -85,6 +85,6 @@ struct PoblenouSkylineView: View {
     var body: some View {
         PoblenouSkyline()
             .stroke(Color.primary.opacity(0.1), style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
-            .aspectRatio(1200/260, contentMode: .fit)
+            .aspectRatio(1200 / 260, contentMode: .fit)
     }
 }

--- a/Sources/Views/ProjectOverviewView.swift
+++ b/Sources/Views/ProjectOverviewView.swift
@@ -271,7 +271,7 @@ struct ProjectOverviewView: View {
 
     private var prunableWorktrees: [WorktreeInfo] {
         return worktrees.filter { worktree in
-            guard !worktree.isMain && !worktree.isDirty && !worktree.hasBranchCommits else { return false }
+            guard !worktree.isMain, !worktree.isDirty, !worktree.hasBranchCommits else { return false }
             return !workstreamPaths.contains(Self.standardizedPath(worktree.path))
         }
     }

--- a/Sources/Views/ProjectSidebar.swift
+++ b/Sources/Views/ProjectSidebar.swift
@@ -160,6 +160,7 @@ struct ProjectSidebar: View {
                             worktreePath: workstream.worktreePath,
                             isPathValid: appEnv.isPathValid(workstream.worktreePath),
                             isActive: activityTracker.isActive(workstream.id),
+                            needsAttention: activityTracker.needsAttention(workstream.id),
                             hasActivePort: appEnv.hasActivePort(workstream.id),
                             githubURL: appEnv.githubURL(for: project.directory),
                             taskDescription: appEnv.taskDescription(for: workstream.worktreePath),
@@ -171,6 +172,15 @@ struct ProjectSidebar: View {
                         )
                         .tag(SidebarSelection.workstream(workstream.id))
                         .padding(.leading, 28)
+                        .listRowBackground(
+                            Group {
+                                if activityTracker.needsAttention(workstream.id) && selection != .workstream(workstream.id) {
+                                    Color.accentColor.opacity(0.15)
+                                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                                        .padding(.horizontal, 4)
+                                }
+                            }
+                        )
                     }
                 }
             }
@@ -771,6 +781,7 @@ private struct WorkstreamRow: View {
     var worktreePath: String?
     let isPathValid: Bool
     var isActive: Bool = false
+    var needsAttention: Bool = false
     var hasActivePort: Bool = false
     var githubURL: URL?
     var taskDescription: String?
@@ -805,14 +816,14 @@ private struct WorkstreamRow: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            ActivityIndicator(isActive: isActive, isPathValid: isPathValid)
+            ActivityIndicator(isActive: isActive, isPathValid: isPathValid, needsAttention: needsAttention)
 
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 4) {
                     Text(headline)
                         .font(.system(size: 12))
                         .strikethrough(!isPathValid)
-                        .foregroundStyle(isPathValid ? .primary : .secondary)
+                        .foregroundStyle(needsAttention ? AnyShapeStyle(Color.accentColor) : (isPathValid ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary)))
                         .lineLimit(1)
                     if hasActivePort {
                         Image(systemName: "circle.fill")
@@ -831,7 +842,7 @@ private struct WorkstreamRow: View {
                             .lineLimit(1)
                     }
                     .font(.system(size: 9, design: .monospaced))
-                    .foregroundStyle(prState == "MERGED" ? AnyShapeStyle(.purple) : AnyShapeStyle(.tertiary))
+                    .foregroundStyle(needsAttention ? AnyShapeStyle(Color.accentColor.opacity(0.8)) : (prState == "MERGED" ? AnyShapeStyle(.purple) : AnyShapeStyle(.tertiary)))
                 }
             }
 
@@ -896,6 +907,7 @@ private struct WorkstreamRow: View {
 private struct ActivityIndicator: View {
     let isActive: Bool
     let isPathValid: Bool
+    var needsAttention: Bool = false
 
     @State private var isPulsing = false
 
@@ -905,6 +917,13 @@ private struct ActivityIndicator: View {
                 Image(systemName: "exclamationmark.triangle")
                     .foregroundStyle(.orange)
                     .font(.system(size: 10))
+            } else if needsAttention {
+                Circle()
+                    .fill(Color.accentColor)
+                    .frame(width: 6, height: 6)
+                    .opacity(isPulsing ? 0.4 : 1.0)
+                    .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: isPulsing)
+                    .onAppear { isPulsing = true }
             } else if isActive {
                 Circle()
                     .fill(.green)

--- a/Tests/TerminalSessionModeTests.swift
+++ b/Tests/TerminalSessionModeTests.swift
@@ -1,8 +1,8 @@
 // ABOUTME: Tests for startup terminal mode resolution.
 // ABOUTME: Verifies tmux-enabled sessions wait for tool detection before launching terminals.
 
-import XCTest
 @testable import FactoryFloor
+import XCTest
 
 final class TerminalSessionModeTests: XCTestCase {
     func testTmuxModeWaitsForToolDetection() {

--- a/Tests/TerminalViewTests.swift
+++ b/Tests/TerminalViewTests.swift
@@ -2,8 +2,8 @@
 // ABOUTME: Verifies AppKit mouse positions are translated to Ghostty's top-left Y axis.
 
 import Cocoa
-import XCTest
 @testable import FactoryFloor
+import XCTest
 
 @MainActor
 final class TerminalViewTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Adds visual notification to workstream tabs when the Coding Agent is waiting for user input (signaled by a terminal bell `\a`).
- Uses the system accent color for the highlight and the text to guide the user's attention.
- Automatically clears the highlight immediately when the user interacts with the terminal (focus, click, or key press) to maintain responsiveness.
- Includes pre-commit `SwiftFormat` and whitespace auto-fixes.

This prevents the user from missing agent questions or confirmations.