### PR TITLE
fix(shortcuts): resolve keyboard navigation bugs and add repo config docs

### DIFF
--- a/REPO_CONFIGURATION.md
+++ b/REPO_CONFIGURATION.md
@@ -1,0 +1,61 @@
+# Adapting Existing Repositories for Factory Floor (Dockyard)
+
+To get the best experience when using Factory Floor (sometimes referred to as Dockyard) with your existing repositories, you need to configure how the IDE sets up, runs, and manages your project's environment.
+
+This guide explains how to properly configure your repository to ensure environment variables are picked up, browsers auto-target your app, and workstreams are provisioned correctly.
+
+## 1. The Configuration File
+
+Factory Floor looks for a configuration file in the root of your repository to understand how to build and run your project. 
+
+Create a `.factoryfloor.json` file in the root of your project:
+
+```json
+{
+  "setup": "npm install",
+  "run": "npm run dev",
+  "teardown": "npm run clean"
+}
+```
+
+### Configuration Keys:
+*   **`setup`**: The command run automatically when a new workstream (branch/worktree) is created. Use this for dependency installation (e.g., `npm install`, `pip install -r requirements.txt`, `cargo fetch`).
+*   **`run`**: The command executed when you press `Cmd+Shift+Return` (Start/Rerun). This should start your local development server.
+*   **`teardown`** *(Optional)*: The command run before a workstream is archived or destroyed. Useful for cleaning up local build artifacts, stopping detached containers, etc.
+
+*Note: Factory Floor also supports legacy fallback configuration names like `.emdash.json`, `conductor.json`, or `.superset/config.json` for backwards compatibility.*
+
+## 2. Environment Variables (`.env`)
+
+When Factory Floor creates a new workstream, it isolates the branch in a dedicated Git worktree (under `~/.factoryfloor/worktrees/`). 
+
+To ensure your environment variables are correctly picked up without manually copying `.env` files around:
+
+1.  Keep your primary `.env` file in your **base repository directory**.
+2.  Factory Floor will automatically **symlink** the `.env` file from the base repository into the root of each new workstream directory (if this feature is enabled in your Factory Floor settings).
+3.  Any modifications to the `.env` file within a workstream will automatically reflect across all your workstreams and the base repository.
+
+## 3. Automatic Port Detection
+
+When you start your project using the `run` command (e.g., `npm run dev`), Factory Floor wraps the process using its `ff-run` launcher. 
+
+You **do not** need to manually configure localhost URLs for the built-in browser. The `ff-run` launcher automatically:
+1.  Monitors the child process tree of your `run` command.
+2.  Detects any listening TCP ports opened by your application.
+3.  Automatically retargets the built-in IDE browser to the detected localhost port (e.g., `http://localhost:3000`).
+
+## 4. Git Worktrees and Branching
+
+Because Factory Floor uses Git worktrees to parallelize work:
+*   **Commit/Stash Changes**: Make sure your base repository is relatively clean. Uncommitted changes in the base repo won't be copied to the isolated workstreams.
+*   **Avoid `.git` Hardcoding**: Avoid scripts that assume `.git` is a directory. In worktrees, `.git` is a file pointing back to the main repository. Most modern tools handle this fine, but custom bash scripts using `[ -d .git ]` might break. Use `git rev-parse --git-dir` instead.
+
+## 5. Adding to `.gitignore`
+
+It's highly recommended to commit `.factoryfloor.json` to your repository so your entire team benefits from zero-config onboarding.
+
+You generally **do not** need to add Factory Floor worktree directories to your `.gitignore`, because Factory Floor provisions worktrees entirely outside of your project path (specifically in `~/.factoryfloor/worktrees/`).
+
+---
+
+By adding a simple `.factoryfloor.json` to your repository root, Factory Floor will seamlessly manage your environment, automate installations, and connect your embedded browser automatically!

--- a/Sources/FF2App.swift
+++ b/Sources/FF2App.swift
@@ -55,9 +55,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Contextual shortcuts via key monitor (avoids cluttering the menu bar)
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-                  let chars = event.charactersIgnoringModifiers
-            else { return event }
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting([.numericPad, .function])
+            guard flags == .command, let chars = event.charactersIgnoringModifiers else { return event }
             if let digit = chars.first?.wholeNumberValue, (1 ... 9).contains(digit) {
                 NotificationCenter.default.post(name: .switchByNumber, object: digit)
                 return nil

--- a/Sources/Terminal/TerminalView.swift
+++ b/Sources/Terminal/TerminalView.swift
@@ -30,6 +30,7 @@ final class TerminalView: NSView {
     private var markedText = NSMutableAttributedString()
     private var keyTextAccumulator: [String]?
     private var activityDebounceWork: DispatchWorkItem?
+    private var windowScreenChangeObserver: NSObjectProtocol?
 
     /// Characters that need backslash-escaping when dropping paths into a terminal.
     private static let shellEscapeCharacters = "\\ ()[]{}<>\"'`!#$&;|*?\t"
@@ -181,21 +182,23 @@ final class TerminalView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard let surface else { return }
-
-        if let screen = window?.screen {
-            ghostty_surface_set_display_id(surface, screen.displayID)
+        
+        if let observer = windowScreenChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowScreenChangeObserver = nil
         }
-
-        // Use backingScaleFactor directly here — the frame may still be the
-        // init placeholder (800×600) before Auto Layout runs, so deriving
-        // scale via convertToBacking(frame) would be unreliable.
-        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
-        ghostty_surface_set_content_scale(surface, scale, scale)
 
         if let window {
-            layer?.contentsScale = window.backingScaleFactor
+            windowScreenChangeObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didChangeScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.updateScreenProperties()
+            }
         }
+        
+        updateScreenProperties()
 
         // Defer size reporting to let Auto Layout settle first.
         // Without this, surfaces added dynamically (e.g., new terminal splits)
@@ -208,9 +211,16 @@ final class TerminalView: NSView {
             }
         }
     }
+    
+    private func updateScreenProperties() {
+        guard let surface else { return }
 
-    override func viewDidChangeBackingProperties() {
-        super.viewDidChangeBackingProperties()
+        if let screen = window?.screen {
+            ghostty_surface_set_display_id(surface, screen.displayID)
+        }
+
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        ghostty_surface_set_content_scale(surface, scale, scale)
 
         if let window {
             CATransaction.begin()
@@ -218,18 +228,15 @@ final class TerminalView: NSView {
             layer?.contentsScale = window.backingScaleFactor
             CATransaction.commit()
         }
-
-        guard let surface else { return }
-
-        let fbFrame = convertToBacking(frame)
-        let xScale = frame.size.width > 0 ? fbFrame.size.width / frame.size.width : 1.0
-        let yScale = frame.size.height > 0 ? fbFrame.size.height / frame.size.height : 1.0
-        ghostty_surface_set_content_scale(surface, xScale, yScale)
-
-        // Scale changed so the framebuffer size changed — re-report.
+        
         if contentSize.width > 0, contentSize.height > 0 {
             reportSizeToSurface(contentSize)
         }
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        updateScreenProperties()
     }
 
     override func setFrameSize(_ newSize: NSSize) {

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -58,20 +58,33 @@ func cycledWorkstreamID(
     return sorted[next].id
 }
 
-func commandKeyNotification(charactersIgnoringModifiers: String?, modifierFlags: NSEvent.ModifierFlags) -> Notification.Name? {
-    guard let charactersIgnoringModifiers else { return nil }
-    let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
-    guard flags.contains(.command), !flags.contains(.option), !flags.contains(.control) else { return nil }
+func commandKeyNotification(event: NSEvent) -> Notification.Name? {
+    let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting([.numericPad, .function])
+    let hasCommand = flags.contains(.command)
     let hasShift = flags.contains(.shift)
+    let hasOption = flags.contains(.option)
+    let hasControl = flags.contains(.control)
 
-    switch (charactersIgnoringModifiers, hasShift) {
-    case ("[", false): return .prevWorkstream
-    case ("]", false): return .nextWorkstream
-    case ("[", true): return .prevTab
-    case ("]", true): return .nextTab
-    case ("w", false): return .closeTerminal
-    default: return nil
+    if hasCommand && !hasControl && !hasOption {
+        if let chars = event.charactersIgnoringModifiers {
+            switch (chars, hasShift) {
+            case ("[", false): return .prevWorkstream
+            case ("]", false): return .nextWorkstream
+            case ("[", true): return .prevTab
+            case ("]", true): return .nextTab
+            case ("w", false): return .closeTerminal
+            default: break
+            }
+        }
+        
+        // Use keycodes for arrows to be reliable
+        switch (event.keyCode, hasShift) {
+        case (125, false): return .nextProject // Down arrow
+        case (126, false): return .prevProject // Up arrow
+        default: break
+        }
     }
+    return nil
 }
 
 struct ContentView: View {
@@ -326,10 +339,7 @@ struct ContentView: View {
                 guard !keyMonitorInstalled else { return }
                 keyMonitorInstalled = true
                 NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                    if let notification = commandKeyNotification(
-                        charactersIgnoringModifiers: event.charactersIgnoringModifiers,
-                        modifierFlags: event.modifierFlags
-                    ) {
+                    if let notification = commandKeyNotification(event: event) {
                         NotificationCenter.default.post(name: notification, object: nil)
                         return nil // swallow the event
                     }


### PR DESCRIPTION
## Summary
- Fixed `Cmd+1-9` tab switching by ignoring `.numericPad` and `.function` modifier flags that are sometimes implicitly added by macOS.
- Fixed project cycling (`Cmd+Up/Down`) by intercepting raw keycodes (125, 126) instead of relying on characters which can be swallowed by the terminal.
- Added `REPO_CONFIGURATION.md` to guide users on configuring their repos for Dockyard / Factory Floor.