### PR TITLE
ci: replace deprecated Node 20 actions with controlled install steps

### DIFF
--- a/.github/actions/install-zig/action.yml
+++ b/.github/actions/install-zig/action.yml
@@ -1,0 +1,29 @@
+# ABOUTME: Composite action that installs a pinned Zig toolchain on macOS runners.
+# ABOUTME: Downloads from ziglang.org and verifies the archive against the published checksum.
+name: Install Zig
+description: Download and install a pinned Zig toolchain with checksum verification
+
+inputs:
+  version:
+    description: Zig version to install (e.g. 0.15.2)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        version="${{ inputs.version }}"
+        case "$(uname -m)" in
+          arm64 | aarch64) arch=aarch64 ;;
+          x86_64) arch=x86_64 ;;
+          *) echo "::error::Unsupported architecture $(uname -m)"; exit 1 ;;
+        esac
+        tarball="zig-${arch}-macos-${version}.tar.xz"
+        expected=$(curl -fsSL https://ziglang.org/download/index.json \
+          | python3 -c "import json,sys;print(json.load(sys.stdin)['${version}']['${arch}-macos']['shasum'])")
+        curl -fsSL -o "${tarball}" "https://ziglang.org/download/${version}/${tarball}"
+        echo "${expected}  ${tarball}" | shasum -a 256 -c -
+        tar -xf "${tarball}"
+        echo "${PWD}/zig-${arch}-macos-${version}" >> "$GITHUB_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,18 +45,15 @@ jobs:
           xcodebuild -version
           swift --version
 
-      - uses: xavierLowmiller/xcodegen-action@1.2.4
-        with:
-          install: true
-          run: false
+      - name: Install XcodeGen
+        run: brew install xcodegen
 
-      - uses: mlugg/setup-zig@v2
+      - name: Install Zig
+        uses: ./.github/actions/install-zig
         with:
           version: 0.15.2
 
       - uses: oven-sh/setup-bun@v2
-
-      - uses: astral-sh/setup-uv@v8.1.0
 
       - name: Cache SPM packages
         uses: actions/cache@v5

--- a/.github/workflows/test-ghostty.yml
+++ b/.github/workflows/test-ghostty.yml
@@ -16,12 +16,11 @@ jobs:
         with:
           submodules: true
 
-      - uses: xavierLowmiller/xcodegen-action@1.2.4
-        with:
-          install: true
-          run: false
+      - name: Install XcodeGen
+        run: brew install xcodegen
 
-      - uses: mlugg/setup-zig@v2
+      - name: Install Zig
+        uses: ./.github/actions/install-zig
         with:
           version: 0.15.2
 


### PR DESCRIPTION
## Summary

Both `xavierLowmiller/xcodegen-action@1.2.4` and `mlugg/setup-zig@v2` still declare the **Node 20** runtime even at their latest versions/`main` (verified against each action's `action.yml`). GitHub forces Node 20 actions to Node 24 on **2026-06-02** and removes Node 20 from runners on **2026-09-16**. Neither has an upstream Node 24 release to bump to, so this replaces them with steps we control.

## Changes

- **XcodeGen** → `brew install xcodegen` (per #151's suggested alternative)
- **Zig** → pinned, checksum-verified download in a new local composite action `.github/actions/install-zig`, referenced from both workflows so the version + integrity check live in one place. The action resolves the published sha256 from `ziglang.org/download/index.json` and verifies the archive before adding it to `PATH`.
- **Removed** the unused `astral-sh/setup-uv@v8.1.0` step from the release job — nothing in the workflow invokes `uv` (it's only used locally in `scripts/setup.sh` for prek hooks). This also clears the empty cache-glob warning noted in #229.

## Validation

- `actionlint` parses all three files cleanly and resolves the local composite action reference; the only remaining warnings are pre-existing SC2086 infos on unchanged lines.
- Ran the composite action's download/checksum/extract logic locally end-to-end: checksum `OK`, `zig version` → `0.15.2`.
- Pre-commit hooks (incl. `check yaml`) pass.

Closes #151
Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)