### PR TITLE
fix(terminal): restore scrollback by reverting tmux alternate-screen overrides

### DIFF
--- a/Sources/Models/TmuxSession.swift
+++ b/Sources/Models/TmuxSession.swift
@@ -36,8 +36,6 @@ enum TmuxSession {
         set -g extended-keys on
         set -g default-terminal "xterm-256color"
         set -ga terminal-features ',*:extkeys'
-        set -ga terminal-overrides ',*:smcup@:rmcup@'
-        set -g alternate-screen off
         set -g aggressive-resize on
         set -g window-size latest
         set -g remain-on-exit on

--- a/Tests/TmuxSessionTests.swift
+++ b/Tests/TmuxSessionTests.swift
@@ -10,14 +10,6 @@ final class TmuxSessionTests: XCTestCase {
         XCTAssertFalse(TmuxSession.configContents.contains("set -g mouse on"))
     }
 
-    func testConfigKeepsOuterTerminalOutOfAlternateScreen() {
-        XCTAssertTrue(TmuxSession.configContents.contains("set -ga terminal-overrides ',*:smcup@:rmcup@'"))
-    }
-
-    func testConfigDisablesPaneAlternateScreen() {
-        XCTAssertTrue(TmuxSession.configContents.contains("set -g alternate-screen off"))
-    }
-
     func testConfigDoesNotGloballyRespawnDeadPanes() {
         XCTAssertFalse(TmuxSession.configContents.contains("pane-died"))
         XCTAssertTrue(TmuxSession.configContents.contains("set -g remain-on-exit on"))


### PR DESCRIPTION
## Summary

Reverts the two tmux settings added in a455855 (`set -g alternate-screen off` and `set -ga terminal-overrides ',*:smcup@:rmcup@'`) that caused the Coding Agent's TUI redraws to pollute the scrollback buffer with duplicated full-screen content (#395).

With these removed, inner programs use their own alternate screen normally and scrollback stays clean.

## Tradeoff

This re-accepts the native trackpad-scroll regression that a455855 originally fixed: inside the alternate screen Ghostty converts scroll events to arrow keys, so trackpad scroll navigates within the TUI rather than the scrollback buffer. Per the discussion in #395, clean scrollback is the preferred behavior; users can navigate with Shift+scroll or the keyboard. `mouse off` is left unchanged.

## Tests

Removed the two tests that asserted the reverted settings (`testConfigKeepsOuterTerminalOutOfAlternateScreen`, `testConfigDisablesPaneAlternateScreen`). Full suite green: `Executed 191 tests, 0 failures`.

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)