### PR TITLE
ci: revert release runners to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: macos-26
+    runs-on: macos-15
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/test-ghostty.yml
+++ b/.github/workflows/test-ghostty.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Why

The v0.1.76 release build failed. Root cause: **zig 0.15.2 cannot link against the macOS 26 SDK** on the `macos-26` runner (Xcode 26.4.1). `zig build` dies linking its own build runner with undefined libSystem symbols (`_abort`, `_malloc_size`, `__availability_version_check`, `dispatch_*`). It surfaced now because the ghostty xcframework cache was cold (6 weeks since last release → evicted), forcing a from-source `zig build`.

zig 0.15.2 is pinned by the ghostty v1.3.1 submodule, so we can't simply bump zig. `mlugg/setup-zig` would fail identically — this is not related to the install method change in #478.

## Change

Revert the runner bump from #472 (`macos-26` → `macos-15`) in `release.yml` and `test-ghostty.yml`. `macos-15` is still GA and built every prior release. Revisit macos-26 when ghostty/zig support the macOS 26 SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)