### PR TITLE
fix(ci): keep appcast history when a previous release has no assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,12 +257,20 @@ jobs:
             exit 1
           fi
 
-          # Download existing appcast from previous release to merge with (preserves items
-          # for the Homebrew update popover). Cannot use --latest because release-please
-          # already created the current (empty) release.
-          PREV_TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 10 --json tagName --jq "[.[] | select(.tagName != \"$TAG_NAME\")][0].tagName")
-          if [ -n "$PREV_TAG" ]; then
-            gh release download "$PREV_TAG" --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output existing-appcast.xml || true
+          # Download an existing appcast to merge with (preserves items for the Homebrew
+          # update popover). Cannot use --latest because release-please already created
+          # the current (empty) release. Walk back through previous releases until one
+          # actually yields an appcast: a release whose build failed carries no assets,
+          # and stopping at it would silently drop every historical item.
+          for CANDIDATE in $(gh release list --repo "$GITHUB_REPOSITORY" --limit 10 --json tagName --jq "[.[] | select(.tagName != \"$TAG_NAME\")][].tagName"); do
+            rm -f existing-appcast.xml
+            if gh release download "$CANDIDATE" --repo "$GITHUB_REPOSITORY" --pattern "appcast.xml" --output existing-appcast.xml 2>/dev/null; then
+              echo "Carrying forward appcast items from $CANDIDATE"
+              break
+            fi
+          done
+          if [ ! -f existing-appcast.xml ]; then
+            echo "::warning::No previous appcast found; this release's appcast will contain only its own item"
           fi
 
           DMG_URL="https://github.com/alltuner/factoryfloor/releases/download/v${VERSION}/${DMG_NAME}"


### PR DESCRIPTION
## Problem

The appcast step merges items from a previous release so the Homebrew update
popover keeps its history. It picked the most recent release other than the one
being built:

```
PREV_TAG=$(gh release list --limit 10 --json tagName --jq "[.[] | select(.tagName != \"$TAG_NAME\")][0].tagName")
```

If that release has no assets, the download fails, `|| true` swallows it, and
`generate_appcast.py` guards on `os.path.exists`, so the build happily publishes
an appcast containing only its own item.

That is not hypothetical: it happened on 0.1.78. Its build ran after 0.1.77,
whose build had failed and left the release empty, so the published 0.1.78
appcast has exactly 1 item where it should have had 77.

Sparkle updates still work, since only the newest item matters for updating.
What breaks is the version history.

## Fix

Walk back through recent releases until one actually yields an appcast, and emit
a warning instead of truncating silently if none does.

## Verification

Ran the new loop against this repository with `TAG_NAME=v0.1.78`:

```
Carrying forward appcast items from v0.1.76
items carried forward: 76
```

It skips the empty v0.1.77 and recovers the history. The old code stopped at
v0.1.77 and carried nothing.

Note this does not retroactively repair the 0.1.78 appcast. The next release
picks up the history again, because v0.1.78 does have an `appcast.xml` asset, so
it self-heals from here.
