### PR TITLE
fix(i18n): add the missing German setup gate strings

### DIFF
--- a/Localization/de.lproj/Localizable.strings
+++ b/Localization/de.lproj/Localizable.strings
@@ -265,10 +265,13 @@
 "Report a Bug" = "Fehler melden";
 "Documentation" = "Dokumentation";
 "Request a Feature" = "Funktion vorschlagen";
-"Rebuild" = "Neu bauen";
 "Rerun" = "Erneut ausführen";
 "Start" = "Starten";
 "Stop" = "Stoppen";
+
+"Running setup..." = "Setup läuft...";
+"Setup failed." = "Setup fehlgeschlagen.";
+"Continue to Agent" = "Weiter zum Agenten";
 
 "Restarting..." = "Wird neu gestartet...";
 "Preparing workstream..." = "Workstream wird vorbereitet...";


### PR DESCRIPTION
## Problem

German was missing three keys, so the setup gate rendered in English for German
users:

- `Running setup...`
- `Setup failed.`
- `Continue to Agent`

These are the strings shown while a project's setup script runs and when it
fails, which is exactly the path that just changed in 0.1.78, so it is a bad one
to leave half translated.

## Changes

Added the three strings:

```
"Running setup..." = "Setup läuft...";
"Setup failed." = "Setup fehlgeschlagen.";
"Continue to Agent" = "Weiter zum Agenten";
```

Also removed `"Rebuild" = "Neu bauen";`, which existed only in German and is
referenced nowhere in `Sources/` or `Resources/`.

## Verification

Audited keys across all five locales. Before: German had 3 missing and 1 orphan.
After, every locale matches English exactly at 248 keys:

```
ca: missing=[] extra=[]
de: missing=[] extra=[]
es: missing=[] extra=[]
sv: missing=[] extra=[]
```

`plutil -lint` passes on all five files.

Not built locally: the ghostty submodule is not checked out in the worktree I was
working from, and building it takes about 15 minutes. This change touches only
`.strings` content with no source references added or removed, and the release
build will exercise it.

## Note, not changed here

All five locales define `"GitHub" = "GitHub";` twice, at lines 82 and 206, once
per section. Identical values, so no functional effect. Left alone rather than
touching five files for cosmetics.
